### PR TITLE
Added case of numpy ndarray to _recursive_torch_to_numpy(...)

### DIFF
--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -671,6 +671,8 @@ class WaveformModel(SeisBenchModel, ABC):
             return [self._recursive_torch_to_numpy(y) for y in x]
         elif isinstance(x, tuple):
             return tuple([self._recursive_torch_to_numpy(y) for y in x])
+        elif isinstance(x, np.ndarray):
+            return x
         else:
             raise ValueError(f"Can't unpack object of type {type(x)}.")
 


### PR DESCRIPTION
Just a simple supplement to the case switch branch in WaveformModel._recursive_torch_to_numpy(...) for the special case when the data is already present in a form of a numpy array.