### PR TITLE
Windows CI

### DIFF
--- a/.github/workflows/test_push.yml
+++ b/.github/workflows/test_push.yml
@@ -2,7 +2,6 @@
 #   1. Checks if black formatting is followed.
 #   2. Runs all tests.
 #
-# Note: Tests are performed on Windows os only to save billable minutes.
 
 name: test_push_action
 on:
@@ -28,10 +27,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [windows-latest]
-        # python-version: [3.6, 3.7, 3.8, 3.9]
-        python-version: [3.6]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         
     steps:
       - uses: actions/checkout@v2
@@ -39,17 +36,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      
-      # - name: Cache pip
-      #   uses: actions/cache@v2
-      #   with:
-      #     # This path is specific to Ubuntu
-      #     path: seisbench_cache
-      #     # Look to see if there is a cache hit for the corresponding requirements file
-      #     key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pip-
-      #       ${{ runner.os }}-
       
       # Load SeisBench cache to ensure data sets are always locally available
       - name: Cache SeisBench

--- a/.github/workflows/test_push.yml
+++ b/.github/workflows/test_push.yml
@@ -1,0 +1,71 @@
+# This workflow runs tests for dev. branch 'windows-ci'. It does the following:
+#   1. Checks if black formatting is followed.
+#   2. Runs all tests.
+#
+# Note: Tests are performed on Windows os only to save billable minutes.
+
+name: test_push_action
+on:
+  push:
+    branches:
+      - windows-ci
+      
+env:
+  SEISBENCH_CACHE_ROOT: seisbench_cache
+
+jobs:
+  black_action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Black Style Check
+        run: |
+          pip install git+git://github.com/psf/black@20.8b1
+          python -m black . --check
+
+  run_tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]
+        # python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6]
+        
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      # - name: Cache pip
+      #   uses: actions/cache@v2
+      #   with:
+      #     # This path is specific to Ubuntu
+      #     path: seisbench_cache
+      #     # Look to see if there is a cache hit for the corresponding requirements file
+      #     key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-pip-
+      #       ${{ runner.os }}-
+      
+      # Load SeisBench cache to ensure data sets are always locally available
+      - name: Cache SeisBench
+        uses: actions/cache@v2
+        with:
+          path: ~/.seisbench
+          key: seisbench-cache-v2
+          restore-keys: |
+            seisbench-cache-v2
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -e .
+      
+      - name: Test with pytest
+        run: |
+          pytest tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-numpy>=1.9
-pandas>=1.1
-h5py>=3.1
-obspy>=1.2
-tqdm>=4.52
-fiona>=1.8.13
-shapely>=1.7.1
-torch>=1.7.0
-scipy>=1.5

--- a/requirements/req_common.txt
+++ b/requirements/req_common.txt
@@ -1,0 +1,7 @@
+numpy>=1.9
+pandas>=1.1
+h5py>=3.1
+obspy>=1.2
+tqdm>=4.52
+torch>=1.7.0
+scipy>=1.5

--- a/requirements/req_dependent.txt
+++ b/requirements/req_dependent.txt
@@ -2,3 +2,4 @@
 gdal>=3.1.4
 shapely>=1.7.1
 fiona>=1.8.18
+cartopy>=0.18.0

--- a/requirements/req_dependent.txt
+++ b/requirements/req_dependent.txt
@@ -1,0 +1,4 @@
+# Packages requiring custom install for diff. os
+gdal>=3.1.4
+shapely>=1.7.1
+fiona>=1.8.18

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -55,9 +55,7 @@ class SeisBenchModel(nn.Module):
 
     @classmethod
     def _remote_path(cls):
-        return os.path.join(
-            seisbench.remote_root, "models", cls._name_internal().lower()
-        )
+        return "/".join((seisbench.remote_root, "models", cls._name_internal().lower()))
 
     @classmethod
     def _pretrained_path(cls, name):
@@ -86,11 +84,11 @@ class SeisBenchModel(nn.Module):
             seisbench.logger.info(f"Weight file {name} not in cache. Downloading...")
             weight_path.parent.mkdir(exist_ok=True, parents=True)
 
-            remote_weight_path = os.path.join(cls._remote_path(), f"{name}.pt")
+            remote_weight_path = f"{cls._remote_path()}/{name}.pt"
             util.download_http(remote_weight_path, weight_path)
 
         def download_metadata_callback(metadata_path):
-            remote_metadata_path = os.path.join(cls._remote_path(), f"{name}.json")
+            remote_metadata_path = f"{cls._remote_path()}/{name}.json"
             try:
                 util.download_http(
                     remote_metadata_path, metadata_path, progress_bar=False

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ if os.name == "nt":
         exit_code_callback(process)
     required = common_req
 else:
-    # Linux, Mac OS: Installation via standard pip
-    required = common_req + dependant_req
+    # Linux, Mac OS: Installation via standard pip - GDAL not req.
+    required = common_req + dependant_req[2:4]
 
 setup(
     name="seisbench",

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,47 @@
+import os
+import subprocess
+import warnings
+
+from pathlib import Path
 from setuptools import setup, find_packages
+
 
 with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
-with open("requirements.txt") as f:
-    required = f.read().splitlines()
+
+with open(Path(os.path.dirname(__file__)) / "requirements" / "req_dependent.txt") as fd:
+    dependant_req = fd.readlines()
+
+with open(Path(os.path.dirname(__file__)) / "requirements" / "req_common.txt") as fc:
+    common_req = fc.readlines()
+
+
+def exit_code_callback(process):
+    _stdout, _stderr = process.communicate()
+
+    if process.returncode != 0:
+        warnings.warn(
+            f"Command '{' '.join(process.args)}' exited with code {process.returncode}."
+        )
+
+
+if os.name == "nt":
+    # Windows: Obtain windows compatible python pkg binaries via pipwin
+    for pkg in ("wheel", "pipwin"):
+        process = subprocess.Popen(
+            ["pip", "install", pkg], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        exit_code_callback(process)
+    for pkg in dependant_req:
+        process = subprocess.Popen(
+            ["pipwin", "install", pkg], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        exit_code_callback(process)
+    required = common_req
+else:
+    # Linux, Mac OS: Installation via standard pip
+    required = common_req + dependant_req
 
 setup(
     name="seisbench",


### PR DESCRIPTION
Summarising the changes in this PR:

- Add custom install dependencies for windows (GDAL lib)
- Install via differing requirements files depending on the OS detected
- Expands the CI tests to include both windows and mac OS systems in the tests

One note to consider for the future is that, whilst the combined installation logic may work at the moment, future dependency conflicts arising due to differing OSs or the versions of the python packages themselves may result in errors when using this combined approach. If this happens, we can change the cartopy, fiona, etc. plotting libs to optional 'soft' dependencies. 