### PR TITLE
Implement triangular labeler

### DIFF
--- a/seisbench/generate/__init__.py
+++ b/seisbench/generate/__init__.py
@@ -16,7 +16,6 @@ from .labeling import (
     SupervisedLabeller,
     PickLabeller,
     ProbabilisticLabeller,
-    TriangularLabeller,
     DetectionLabeller,
     StandardLabeller,
     ProbabilisticPointLabeller,

--- a/seisbench/generate/__init__.py
+++ b/seisbench/generate/__init__.py
@@ -16,6 +16,7 @@ from .labeling import (
     SupervisedLabeller,
     PickLabeller,
     ProbabilisticLabeller,
+    TriangularLabeller,
     DetectionLabeller,
     StandardLabeller,
     ProbabilisticPointLabeller,

--- a/seisbench/generate/labeling.py
+++ b/seisbench/generate/labeling.py
@@ -343,7 +343,9 @@ class TriangularLabeller(PickLabeller):
                 for j in range(X.shape[sample_dim]):
                     onset = metadata[label_column][j]
                     label_val = triangular_pick(
-                        onset=onset, length=X.shape[width_dim], half_width=self.half_width
+                        onset=onset,
+                        length=X.shape[width_dim],
+                        half_width=self.half_width,
                     )
                     label_val[
                         np.isnan(label_val)
@@ -833,9 +835,9 @@ def triangular_pick(onset, length, half_width):
     :rtype: np.ndarray
     """
     x = np.linspace(1, length, length)
-    y1 = -(x - onset)/half_width + 1
-    y1 *= (y1>=0) & (y1 <=1)
-    y2 = (x - onset)/half_width + 1
-    y2 *= (y2>=0) & (y2 <=1)
+    y1 = -(x - onset) / half_width + 1
+    y1 *= (y1 >= 0) & (y1 <= 1)
+    y2 = (x - onset) / half_width + 1
+    y2 *= (y2 >= 0) & (y2 <= 1)
     y = y1 + y2
     return y

--- a/seisbench/generate/labeling.py
+++ b/seisbench/generate/labeling.py
@@ -271,6 +271,109 @@ class ProbabilisticLabeller(PickLabeller):
         return f"ProbabilisticLabeller (label_type={self.label_type}, dim={self.dim})"
 
 
+class TriangularLabeller(PickLabeller):
+    r"""
+    Create supervised labels from picks. The picks in example are represented
+    probabilistically with a triangular label. Class transferred from ProbabilisticLabeller
+            / \
+           /   \
+          /     \
+         /       \
+        /         \
+    ___/           \___
+       ----- | -----
+        2*half_width
+
+    All picks with NaN sample are treated as not present.
+
+    :param half_width: The half width of the triangular distribution in samples
+    :type half_width: int, optional
+    """
+
+    def __init__(self, half_width=10, **kwargs):
+        self.label_method = "probabilistic"
+        self.half_width = half_width
+        kwargs["dim"] = kwargs.get("dim", 1)
+        super().__init__(label_type="multi_class", **kwargs)
+
+    def label(self, X, metadata):
+        if not self.label_columns:
+            label_columns = self._auto_identify_picklabels(metadata)
+            (
+                self.label_columns,
+                self.labels,
+                self.label_ids,
+            ) = self._colums_to_dict_and_labels(label_columns)
+
+        sample_dim, channel_dim, width_dim = self._get_dimension_order_from_config(
+            config, self.ndim
+        )
+
+        if self.ndim == 2:
+            y = np.zeros(shape=(len(self.labels), X.shape[width_dim]))
+        elif self.ndim == 3:
+            y = np.zeros(
+                shape=(
+                    X.shape[sample_dim],
+                    len(self.labels),
+                    X.shape[width_dim],
+                )
+            )
+
+        # Construct pick labels
+        for label_column, label in self.label_columns.items():
+            i = self.label_ids[label]
+
+            if label_column not in metadata:
+                # Unknown pick
+                continue
+
+            if isinstance(metadata[label_column], (int, np.integer, float)):
+                # Handle single window case
+                onset = metadata[label_column]
+                label_val = triangular_pick(
+                    onset=onset, length=X.shape[width_dim], half_width=self.half_width
+                )
+                label_val[
+                    np.isnan(label_val)
+                ] = 0  # Set non-present pick probabilities to 0
+                y[i, :] = np.maximum(y[i, :], label_val)
+            else:
+                # Handle multi-window case
+                for j in range(X.shape[sample_dim]):
+                    onset = metadata[label_column][j]
+                    label_val = triangular_pick(
+                        onset=onset, length=X.shape[width_dim], half_width=self.half_width
+                    )
+                    label_val[
+                        np.isnan(label_val)
+                    ] = 0  # Set non-present pick probabilities to 0
+                    y[j, i, :] = np.maximum(y[j, i, :], label_val)
+
+        y /= np.maximum(
+            1, np.nansum(y, axis=channel_dim, keepdims=True)
+        )  # Ensure total probability mass is at most 1
+
+        # Construct noise label
+        if self.ndim == 2:
+            y[self.label_ids["Noise"], :] = 1 - np.nansum(y, axis=channel_dim)
+            y = self._swap_dimension_order(
+                y,
+                current_dim="CW",
+                expected_dim=config["dimension_order"].replace("N", ""),
+            )
+        elif self.ndim == 3:
+            y[:, self.label_ids["Noise"], :] = 1 - np.nansum(y, axis=channel_dim)
+            y = self._swap_dimension_order(
+                y, current_dim="NCW", expected_dim=config["dimension_order"]
+            )
+
+        return y
+
+    def __str__(self):
+        return f"TriangularLabeller (label_type={self.label_type}, dim={self.dim})"
+
+
 class StepLabeller(PickLabeller):
     """
     Create supervised labels from picks. The picks are represented by probability curves with value 0
@@ -713,3 +816,26 @@ def gaussian_pick(onset, length, sigma):
     """
     x = np.linspace(1, length, length)
     return np.exp(-np.power(x - onset, 2.0) / (2 * np.power(sigma, 2.0)))
+
+
+def triangular_pick(onset, length, half_width):
+    r"""
+    Create triangular representation of pick in time series.
+    Transffered from gaussian_pick
+
+    :param onset: The nearest sample to pick onset
+    :type onset: float
+    :param length: The length of the trace time series in samples
+    :type length: int
+    :param half_width: The half width of the triangular distribution in samples
+    :type half_width: float
+    :return y: 1D time series with triangular representation of pick
+    :rtype: np.ndarray
+    """
+    x = np.linspace(1, length, length)
+    y1 = -(x - onset)/half_width + 1
+    y1 *= (y1>=0) & (y1 <=1)
+    y2 = (x - onset)/half_width + 1
+    y2 *= (y2>=0) & (y2 <=1)
+    y = y1 + y2
+    return y

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,3 +1,6 @@
+import sys
+
+sys.path.append("/home/niyiyu/Research/MachineLearning/seisbench/")
 import seisbench.generate
 import seisbench.generate.labeling
 from seisbench.generate import (
@@ -577,7 +580,7 @@ def test_change_dtype():
 
 
 def test_probabilistic_pick_labeller():
-    for form in ['gaussian', 'triangular']:
+    for form in ["gaussian", "triangular", "box"]:
         np.random.seed(42)
         state_dict = {
             "X": (
@@ -592,19 +595,23 @@ def test_probabilistic_pick_labeller():
 
         # Assumes standard config['dimension_order'] = 'NCW'
         # Test label construction for single window, handling NaN values
-        labeller = ProbabilisticLabeller(dim=0, form = form)
+        labeller = ProbabilisticLabeller(dim=0, form=form)
         labeller(state_dict)
 
         assert state_dict["y"][0].shape == (4, 1000)
-        assert np.argmax(state_dict["y"][0], axis=1)[1] == 499
-        assert np.argmax(state_dict["y"][0], axis=1)[2] == 699
+        if form == "box":
+            assert np.array_equiv(state_dict["y"][0][1][490:510], np.ones(20))
+            assert np.array_equiv(state_dict["y"][0][2][690:710], np.ones(20))
+        else:
+            assert np.argmax(state_dict["y"][0], axis=1)[1] == 499
+            assert np.argmax(state_dict["y"][0], axis=1)[2] == 699
         assert (
             state_dict["y"][0][0] == 0
         ).all()  # Check that NaN picks are interpreted as not present
 
         # Fails when multi_class specified and channel dim sum > 1
         with pytest.raises(ValueError):
-            labeller = ProbabilisticLabeller(dim=1, form = form)
+            labeller = ProbabilisticLabeller(dim=1, form=form)
             labeller(state_dict)
 
         # Test label construction for multiple windows
@@ -618,13 +625,22 @@ def test_probabilistic_pick_labeller():
                 },
             )
         }
-        labeller = ProbabilisticLabeller(dim=1, form = form)
+        labeller = ProbabilisticLabeller(dim=1, form=form)
         labeller(state_dict)
 
         assert state_dict["y"][0].shape == (5, 4, 1000)
-        assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[1] == 499
-        assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[2] == 699
-        assert np.argmax(state_dict["y"][0][2, :, :], axis=-1)[0] == 199  # Entry with pick
+        if form == "box":
+            assert np.array_equiv(state_dict["y"][0][3, 1, 490:510], np.ones(20))
+            assert np.array_equiv(state_dict["y"][0][3, 2, 690:710], np.ones(20))
+            assert np.array_equiv(
+                state_dict["y"][0][2, 0, 190:210], np.ones(20)
+            )  # Entry with pick
+        else:
+            assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[1] == 499
+            assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[2] == 699
+            assert (
+                np.argmax(state_dict["y"][0][2, :, :], axis=-1)[0] == 199
+            )  # Entry with pick
         assert (state_dict["y"][0][3, 0, :] == 0).all()
 
         # Fails if single sample provided for multiple windows
@@ -638,14 +654,14 @@ def test_probabilistic_pick_labeller():
             )
         }
         with pytest.raises(ValueError):
-            labeller = ProbabilisticLabeller(dim=1, form = form)
+            labeller = ProbabilisticLabeller(dim=1, form=form)
             labeller(state_dict)
 
         state_dict["X"] = np.random.rand(10, 5, 3, 1000)
 
         # Fails if non-compatible input data dimensions are provided
         with pytest.raises(ValueError):
-            labeller = ProbabilisticLabeller(dim=1, form = form)
+            labeller = ProbabilisticLabeller(dim=1, form=form)
             labeller(state_dict)
 
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -648,6 +648,7 @@ def test_probabilistic_pick_labeller():
         labeller = ProbabilisticLabeller(dim=1)
         labeller(state_dict)
 
+
 def test_triangular_pick_labeller():
     np.random.seed(42)
     state_dict = {

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,6 +1,3 @@
-import sys
-
-sys.path.append("/home/niyiyu/Research/MachineLearning/seisbench/")
 import seisbench.generate
 import seisbench.generate.labeling
 from seisbench.generate import (
@@ -580,7 +577,7 @@ def test_change_dtype():
 
 
 def test_probabilistic_pick_labeller():
-    for form in ["gaussian", "triangular", "box"]:
+    for shape in ["gaussian", "triangle", "box"]:
         np.random.seed(42)
         state_dict = {
             "X": (
@@ -595,11 +592,11 @@ def test_probabilistic_pick_labeller():
 
         # Assumes standard config['dimension_order'] = 'NCW'
         # Test label construction for single window, handling NaN values
-        labeller = ProbabilisticLabeller(dim=0, form=form)
+        labeller = ProbabilisticLabeller(dim=0, shape=shape)
         labeller(state_dict)
 
         assert state_dict["y"][0].shape == (4, 1000)
-        if form == "box":
+        if shape == "box":
             assert np.array_equiv(state_dict["y"][0][1][490:510], np.ones(20))
             assert np.array_equiv(state_dict["y"][0][2][690:710], np.ones(20))
         else:
@@ -611,7 +608,7 @@ def test_probabilistic_pick_labeller():
 
         # Fails when multi_class specified and channel dim sum > 1
         with pytest.raises(ValueError):
-            labeller = ProbabilisticLabeller(dim=1, form=form)
+            labeller = ProbabilisticLabeller(dim=1, shape=shape)
             labeller(state_dict)
 
         # Test label construction for multiple windows
@@ -625,11 +622,11 @@ def test_probabilistic_pick_labeller():
                 },
             )
         }
-        labeller = ProbabilisticLabeller(dim=1, form=form)
+        labeller = ProbabilisticLabeller(dim=1, shape=shape)
         labeller(state_dict)
 
         assert state_dict["y"][0].shape == (5, 4, 1000)
-        if form == "box":
+        if shape == "box":
             assert np.array_equiv(state_dict["y"][0][3, 1, 490:510], np.ones(20))
             assert np.array_equiv(state_dict["y"][0][3, 2, 690:710], np.ones(20))
             assert np.array_equiv(
@@ -654,14 +651,14 @@ def test_probabilistic_pick_labeller():
             )
         }
         with pytest.raises(ValueError):
-            labeller = ProbabilisticLabeller(dim=1, form=form)
+            labeller = ProbabilisticLabeller(dim=1, shape=shape)
             labeller(state_dict)
 
         state_dict["X"] = np.random.rand(10, 5, 3, 1000)
 
         # Fails if non-compatible input data dimensions are provided
         with pytest.raises(ValueError):
-            labeller = ProbabilisticLabeller(dim=1, form=form)
+            labeller = ProbabilisticLabeller(dim=1, shape=shape)
             labeller(state_dict)
 
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -11,6 +11,7 @@ from seisbench.generate import (
     SteeredWindow,
     ChangeDtype,
     ProbabilisticLabeller,
+    TriangularLabeller,
     ProbabilisticPointLabeller,
     StandardLabeller,
     DetectionLabeller,
@@ -645,6 +646,77 @@ def test_probabilistic_pick_labeller():
     # Fails if non-compatible input data dimensions are provided
     with pytest.raises(ValueError):
         labeller = ProbabilisticLabeller(dim=1)
+        labeller(state_dict)
+
+def test_triangular_pick_labeller():
+    np.random.seed(42)
+    state_dict = {
+        "X": (
+            10 * np.random.rand(3, 1000),
+            {
+                "trace_p_arrival_sample": 500,
+                "trace_s_arrival_sample": 700,
+                "trace_g_arrival_sample": np.nan,
+            },
+        )
+    }
+
+    # Assumes standard config['dimension_order'] = 'NCW'
+    # Test label construction for single window, handling NaN values
+    labeller = TriangularLabeller(dim=0)
+    labeller(state_dict)
+
+    assert state_dict["y"][0].shape == (4, 1000)
+    assert np.argmax(state_dict["y"][0], axis=1)[1] == 499
+    assert np.argmax(state_dict["y"][0], axis=1)[2] == 699
+    assert (
+        state_dict["y"][0][0] == 0
+    ).all()  # Check that NaN picks are interpreted as not present
+
+    # Fails when multi_class specified and channel dim sum > 1
+    with pytest.raises(ValueError):
+        labeller = TriangularLabeller(dim=1)
+        labeller(state_dict)
+
+    # Test label construction for multiple windows
+    state_dict = {
+        "X": (
+            10 * np.random.rand(5, 3, 1000),
+            {
+                "trace_p_arrival_sample": np.array([500] * 5),
+                "trace_s_arrival_sample": np.array([700] * 5),
+                "trace_g_arrival_sample": np.array([500, 500, 200, np.nan, 500]),
+            },
+        )
+    }
+    labeller = TriangularLabeller(dim=1)
+    labeller(state_dict)
+
+    assert state_dict["y"][0].shape == (5, 4, 1000)
+    assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[1] == 499
+    assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[2] == 699
+    assert np.argmax(state_dict["y"][0][2, :, :], axis=-1)[0] == 199  # Entry with pick
+    assert (state_dict["y"][0][3, 0, :] == 0).all()
+
+    # Fails if single sample provided for multiple windows
+    state_dict = {
+        "X": (
+            10 * np.random.rand(5, 3, 1000),
+            {
+                "trace_p_arrival_sample": 500,
+                "trace_s_arrival_sample": 700,
+            },
+        )
+    }
+    with pytest.raises(ValueError):
+        labeller = TriangularLabeller(dim=1)
+        labeller(state_dict)
+
+    state_dict["X"] = np.random.rand(10, 5, 3, 1000)
+
+    # Fails if non-compatible input data dimensions are provided
+    with pytest.raises(ValueError):
+        labeller = TriangularLabeller(dim=1)
         labeller(state_dict)
 
 


### PR DESCRIPTION
Hi @yetinam ,

Triangular labels have been used to train Earthquake Transformer in [Mousavi et al., 2020](https://www.nature.com/articles/s41467-020-17591-w), while Seisbench does not implement it yet. 

Here I built the TriangularLabeller which is similar to the ProbabilisticLabeller class. It's a pretty small commit, and hopefully will be useful for future users.


<img width="692" alt="Screen Shot 2022-03-08 at 14 50 30" src="https://user-images.githubusercontent.com/36231703/157339105-8934d672-24bd-4fee-ad71-055796917f25.png">


 