### PR TITLE
Implement model weight versioning (#76)

### DIFF
--- a/docs/pages/models.rst
+++ b/docs/pages/models.rst
@@ -42,6 +42,8 @@ Loading pretrained models
 For annotating waveforms in a meaningful way, trained model weights are required.
 SeisBench offers a range of pretrained model weights through a common interface.
 Model weights are downloaded on the first use and cached locally afterwards.
+For some model weights, multiple versions are available.
+For details on accessing these, check the documentation at :py:class:`~seisbench.models.base.SeisBenchModel.from_pretrained`.
 
 .. code-block:: python
 


### PR DESCRIPTION
This commit adds versioning for model weights. This commit includes the following changes:
- Added a weights_version property to SeisBenchModel.
- Added a "version" field to json configs of model weights.
- json config files are now mandatory for each set of model weights (but using the standard pytorch interface, it is still possible to load weights without config).
- The local cache structure now stores models as [name].[json|pt].v[version], i.e., a version suffix was added. Old caches are automatically converted. For compatibility reasons, the required remote cache structure is still downward-compatible.
- The list_pretrained function now takes local models into account.
- Added list_versions function.
- Implemented fine-grained control whether the remote repository or the local cache should be used.
- The documentation has been updated to include a remark on versioning.

In addition, the control flow of these functions was modified. Tests for all changes were added.