### PR TITLE
Implement parallel backend for annotate and extend documentation on parallelism

### DIFF
--- a/seisbench/models/phasenet.py
+++ b/seisbench/models/phasenet.py
@@ -7,7 +7,7 @@ import numpy as np
 
 class PhaseNet(WaveformModel):
     def __init__(
-        self, in_channels=3, classes=3, phases=None, sampling_rate=100, **kwargs
+        self, in_channels=3, classes=3, phases="NPS", sampling_rate=100, **kwargs
     ):
         citation = (
             "Zhu, W., & Beroza, G. C. (2019). "

--- a/seisbench/util/__init__.py
+++ b/seisbench/util/__init__.py
@@ -13,3 +13,4 @@ from .trace_ops import (
     trace_has_spikes,
     waveform_id_to_network_station_location,
 )
+from .decorators import log_lifecycle

--- a/seisbench/util/decorators.py
+++ b/seisbench/util/decorators.py
@@ -1,0 +1,20 @@
+import seisbench
+import functools
+
+
+def log_lifecycle(level):
+    """
+    Logs the invocation and termination of a function to seisbench.logger. Should be used as a decorator.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def f(*args, **kwargs):
+            seisbench.logger.log(msg=f"Starting {func.__name__}", level=level)
+            res = func(*args, **kwargs)
+            seisbench.logger.log(msg=f"Stopping {func.__name__}", level=level)
+            return res
+
+        return f
+
+    return decorator

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -117,3 +117,15 @@ def test_precheck_url(caplog):
         with caplog.at_level(logging.WARNING):
             seisbench.util.precheck_url(seisbench.remote_root, timeout=5)
         assert "status code 400" in caplog.text
+
+
+def test_log_lifecycle(caplog):
+    @seisbench.util.log_lifecycle(logging.DEBUG)
+    def test_func():
+        pass
+
+    with caplog.at_level(logging.DEBUG):
+        test_func()
+
+    assert "Starting test_func" in caplog.text
+    assert "Stopping test_func" in caplog.text


### PR DESCRIPTION
This PR adds a parallel backend for `WaveformModel.annotate`. However, as the overhead for starting processes in python is rather large, this would lead to large runtime increases when annotating short waveform fragments. Therefore, I implemented a dual system with two options to choose from for the user:

- the previous `asyncio` based implementation, which is particularly well suited for small inputs
- a new `multiprocessing` based implementation, which is aimed at annotating large inputs, where the overhead becomes small compared to the total runtime.

The amount of code required for implementing a new model stays unchanged.
In addition, this PR extends the documentation with hints on multiprocessing.