### PR TITLE
Suppress warning for mixed dtypes when loading metadata

### DIFF
--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -14,6 +14,7 @@ import scipy.signal
 import copy
 from collections import defaultdict
 from collections.abc import Iterable
+import warnings
 
 
 class WaveformDataset:
@@ -113,10 +114,14 @@ class WaveformDataset:
 
         metadatas = []
         for chunk, metadata_path, _ in zip(*self._chunks_with_paths()):
-            tmp_metadata = pd.read_csv(
-                metadata_path,
-                dtype={"trace_sampling_rate_hz": float, "trace_dt_s": float},
-            )
+            with warnings.catch_warnings():
+                # Catch warning for mixed dtype
+                warnings.filterwarnings("ignore", category=pd.errors.DtypeWarning)
+
+                tmp_metadata = pd.read_csv(
+                    metadata_path,
+                    dtype={"trace_sampling_rate_hz": float, "trace_dt_s": float},
+                )
             tmp_metadata["trace_chunk"] = chunk
             metadatas.append(tmp_metadata)
         self._metadata = pd.concat(metadatas)


### PR DESCRIPTION
This PR suppresses the pandas warning for mixed dtypes when loading the metadata from csv. It occurs primarily because we allow empty metadata fields. However, the warning can be pretty annoying, in particular, when loading datasets with many chunks because each chunk will trigger a warning. At the same time, we cannot pass a dictionary with dtypes to `read_csv` due to the flexible names of metadata columns. I think suppressing the warning should be fine here.

@jawooll : Just running this by you to see if you agree on hiding the warning.