### PR TITLE
Add max-stack option to reassemble array predictions

### DIFF
--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -683,7 +683,11 @@ class WaveformModel(SeisBenchModel, ABC):
     :type grouping: str
     :param kwargs: Kwargs are passed to the superclass
     """
-    _stack_options = {"avg", "max"}  # Known stacking options - mutable and accessible for docs.
+
+    _stack_options = {
+        "avg",
+        "max",
+    }  # Known stacking options - mutable and accessible for docs.
 
     def __init__(
         self,
@@ -1588,8 +1592,12 @@ class WaveformModel(SeisBenchModel, ABC):
         Reassembles array predictions into numpy arrays.
         """
         overlap = argdict.get("overlap", 0)
-        stack_method = argdict.get("stacking", "max").lower()  # This is a breaking change for v 0.3 - see PR#99
-        assert stack_method in self._stack_options, f"Stacking method {stack_method} unknown. Known options are: {self._stack_options}"
+        stack_method = argdict.get(
+            "stacking", "max"
+        ).lower()  # This is a breaking change for v 0.3 - see PR#99
+        assert (
+            stack_method in self._stack_options
+        ), f"Stacking method {stack_method} unknown. Known options are: {self._stack_options}"
         window, metadata = elem
         t0, s, len_starts, trace_stats, bucket_id = metadata
         key = f"{t0}_{trace_stats.network}.{trace_stats.station}.{trace_stats.station}.{trace_stats.channel[:-1]}"
@@ -1631,7 +1639,9 @@ class WaveformModel(SeisBenchModel, ABC):
 
             with warnings.catch_warnings():
                 if stack_method == "avg":
-                    warnings.filterwarnings(action="ignore", message="Mean of empty slice")
+                    warnings.filterwarnings(
+                        action="ignore", message="Mean of empty slice"
+                    )
                     preds = np.nanmean(pred_merge, axis=-1)
                 elif stack_method == "max":
                     warnings.filterwarnings(action="ignore", message="All-NaN")

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -1587,6 +1587,7 @@ class WaveformModel(SeisBenchModel, ABC):
         Reassembles array predictions into numpy arrays.
         """
         overlap = argdict.get("overlap", 0)
+        max_stack = argdict.get("max_stack", False)  # Default is to stack prediction cfts by mean.
         window, metadata = elem
         t0, s, len_starts, trace_stats, bucket_id = metadata
         key = f"{t0}_{trace_stats.network}.{trace_stats.station}.{trace_stats.station}.{trace_stats.channel[:-1]}"
@@ -1628,7 +1629,11 @@ class WaveformModel(SeisBenchModel, ABC):
 
             with warnings.catch_warnings():
                 warnings.filterwarnings(action="ignore", message="Mean of empty slice")
-                preds = np.nanmean(pred_merge, axis=-1)
+                warnings.filterwarnings(action="ignore", message="All-NaN")
+                if not max_stack:
+                    preds = np.nanmean(pred_merge, axis=-1)
+                else:
+                    preds = np.nanmax(pred_merge, axis=-1)
 
             pred_time = t0 + self.pred_sample[0] / argdict["sampling_rate"]
             pred_rate = argdict["sampling_rate"] * prediction_sample_factor

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -1646,6 +1646,7 @@ class WaveformModel(SeisBenchModel, ABC):
                 elif stack_method == "max":
                     warnings.filterwarnings(action="ignore", message="All-NaN")
                     preds = np.nanmax(pred_merge, axis=-1)
+                # Case of stack_method not in avg or max is caught by assert above
 
             pred_time = t0 + self.pred_sample[0] / argdict["sampling_rate"]
             pred_rate = argdict["sampling_rate"] * prediction_sample_factor

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -633,7 +633,7 @@ def test_reassemble_blocks_array():
     assert out[0][2].shape == (10001, 3)
 
 
-def test_reassemble_blocks_array_maxstack():
+def test_reassemble_blocks_array_stack_options():
     # Check that the maximum is taken when stacking
     dummy = DummyWaveformModel(
         component_order="ZNE", in_samples=1000, sampling_rate=100, pred_sample=(0, 1000)
@@ -641,54 +641,30 @@ def test_reassemble_blocks_array_maxstack():
 
     trace_stats = obspy.read()[0].stats
 
-    out = []
-    argdict = {"overlap": 100, "stacking": "max", "sampling_rate": 100}
-    buffer = defaultdict(list)
+    for stacking in {"max", "avg"}:
+        out = []
+        argdict = {"overlap": 100, "stacking": stacking, "sampling_rate": 100}
+        buffer = defaultdict(list)
 
-    starts = [0, 900, 1800, 2700, 3600, 4500, 5400, 6300, 7200, 8100, 9000, 9001]
+        starts = [0, 900, 1800, 2700, 3600, 4500, 5400, 6300, 7200, 8100, 9000, 9001]
 
-    for i in range(12):
-        elem = (np.ones((1000, 3)) + i, (0, starts[i], 12, trace_stats, 0))
-        out_elem = dummy._reassemble_blocks_array(elem, buffer, argdict)
-        if out_elem is not None:
-            out += [out_elem[0]]
+        for i in range(12):
+            elem = (np.ones((1000, 3)) + i, (0, starts[i], 12, trace_stats, 0))
+            out_elem = dummy._reassemble_blocks_array(elem, buffer, argdict)
+            if out_elem is not None:
+                out += [out_elem[0]]
 
-    assert len(out) == 1
-    assert out[0][0] == 100.0
-    assert out[0][2].shape == (10001, 3)
-    assert out[0][2].min() == 1
-    assert out[0][2].max() == 12
-    # In the max stacking scheme the last window length samples should be equal to the max
-    assert np.all(out[0][2][-1000:] == 12)
-
-
-def test_reassemble_blocks_array_avgstack():
-    # Check that the maximum is taken when stacking
-    dummy = DummyWaveformModel(
-        component_order="ZNE", in_samples=1000, sampling_rate=100, pred_sample=(0, 1000)
-    )
-
-    trace_stats = obspy.read()[0].stats
-
-    out = []
-    argdict = {"overlap": 100, "stacking": "avg", "sampling_rate": 100}
-    buffer = defaultdict(list)
-
-    starts = [0, 900, 1800, 2700, 3600, 4500, 5400, 6300, 7200, 8100, 9000, 9001]
-
-    for i in range(12):
-        elem = (np.ones((1000, 3)) + i, (0, starts[i], 12, trace_stats, 0))
-        out_elem = dummy._reassemble_blocks_array(elem, buffer, argdict)
-        if out_elem is not None:
-            out += [out_elem[0]]
-
-    assert len(out) == 1
-    assert out[0][0] == 100.0
-    assert out[0][2].shape == (10001, 3)
-    assert out[0][2].min() == 1
-    assert out[0][2].max() == 12
-    # In the avg stacking scheme the samples from 9100 to 10000 should be equal to the mean of 11, 12
-    assert np.all(out[0][2][9100:10000] == 11.5)
+        assert len(out) == 1
+        assert out[0][0] == 100.0
+        assert out[0][2].shape == (10001, 3)
+        assert out[0][2].min() == 1
+        assert out[0][2].max() == 12
+        if stacking == "max":
+            # In the max stacking scheme the last window length samples should be equal to the max
+            assert np.all(out[0][2][-1000:] == 12)
+        elif stacking == "avg":
+            # In the avg stacking scheme the samples from 9100 to 10000 should be equal to the mean of 11, 12
+            assert np.all(out[0][2][9100:10000] == 11.5)
 
 
 def test_picks_from_annotations():


### PR DESCRIPTION
## Possible enhancement/discussion point
Currently prediction time-series from overlapping windows are combined into one prediction time-series spanning the entire stream fed to the model. To combine these overlapping windows the average of these windows is taken. For EQTransformer combining by taking the mean is not ideal as the prediction value depends quite strongly on when the phase occurs within the 60s window used for prediction. 

Consider the below case for the same earthquake recorded on site SNZO (and reported in the [EQTransformer paper](https://www.nature.com/articles/s41467-020-17591-w/figures/4):

```python
from obspy import UTCDateTime
from obspy.clients.fdsn import Client
import numpy as np
import seisbench.models as sbm
import matplotlib.pyplot as plt

def plot_predictions(tr, cft, p_time):
    colors = {"Detection": "green", "P": "red", "S": "blue"}
    fig, ax = plt.subplots()
    ax.plot(tr.times(reftime=p_time), tr.data / np.max(np.abs(tr.data)), color="grey", alpha=0.4, label=tr.id)
    for _tr in cft:
        cft_type = _tr.stats.channel.split('_')[-1]
        color = colors.get(cft_type, 'k')
        ax.plot(_tr.times(reftime=p_time), _tr.data, color=color, label=cft_type)
    ax.legend()
    return fig

p_time = UTCDateTime(2001, 10, 13, 12, 47, 39, 257)
client = Client("IRIS")
st = client.get_waveforms(
    network="IU", station="SNZO", location="10", channel="BH?",
    starttime=p_time - 360, endtime=p_time + 420)
st = st.interpolate(sampling_rate=100.0)

model = sbm.EQTransformer.from_pretrained("original")

# First detect with P-arrival at 10-seconds into window
chunk = st.slice(p_time - 10, p_time + 50)
cft = model.annotate(chunk)
fig_1 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_1.suptitle('P at 10s')

# Try again with the P-arrival at 20-seconds
chunk = st.slice(p_time - 20, p_time + 40)
cft = model.annotate(chunk)
fig_2 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_2.suptitle('P at 20s')

# Try again with the P-arrival at 30-seconds
chunk = st.slice(p_time - 30, p_time + 30)
cft = model.annotate(chunk)
fig_3 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_3.suptitle('P at 30s')
plt.show()
```

### P at 10s
![SNZO_P10](https://user-images.githubusercontent.com/10913395/173466876-3005eeca-8bb2-4864-b1c0-5dc553c569cc.png)
t 10s

### P at 20s
![SNZO_P20](https://user-images.githubusercontent.com/10913395/173466897-45180c84-114a-485d-8fcf-f818dc957631.png)

### P at 30s
![SNZO_P30](https://user-images.githubusercontent.com/10913395/173466908-55578187-07ba-4b2f-8921-6308e91fb44b.png)


In this example the main issue is likely that the whole event does not fit in the detection window when the P arrival is much later than 20s into the window. The result of this when overlapping windows and stacking as the mean of the overlaps is that the predictions are degraded by windows for which the P arrival is not at the optimum position:

```
# Using the default 18s overlap
chunk = st.slice(p_time - 10, p_time + 68)
cft = model.annotate(chunk)
fig_1 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_1.show()
```

![SNZO_P10_overlapped](https://user-images.githubusercontent.com/10913395/173467541-587dcfbc-d499-4d3a-999d-b6858f73f9af.png)

This gets worse for larger overlaps:
```
model.default_args['overlap'] = int(50 * model.sampling_rate)
cft = model.annotate(chunk)
fig_1 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_1.show()
```

![SNZO_P10_overlapped_50s](https://user-images.githubusercontent.com/10913395/173467633-a0ee4943-f27d-4bbd-912b-ee58acbc7ff0.png)

And even worse for a more general case where the first window is not the "ideal" window:
```
chunk = st.slice(p_time - 40, p_time + 68)
cft = model.annotate(chunk)
fig_1 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_1.show()
```

![SNZO_P-40_overlapped_50s](https://user-images.githubusercontent.com/10913395/173467763-17a36e9c-a28d-4558-b982-4efe9789bd8e.png)

The key point arising from this is that stacking as the average of overlapping prediction windows, at least for EQTransformer, results in degraded prediction arrays and resulting predictions. This can result in missing detections or picks. In EQTransformer itself it looks like this issue is circumvented by [picking on each window individually](https://github.com/smousavi05/EQTransformer/blob/01bf112a00c1a3bbb43adb2c7dba3e21b5fbcdb9/EQTransformer/core/mseed_predictor.py#L318) and combining the picks later, although this does seem to result in pick duplication.

I suggest that instead of either of the above options it might be better to pick on the combined predictions, but combined by taking the maximum values in overlapping windows. This assumes that each discrete window is either "correct" (if the arrivals occur in "optimal" locations in the window) or under predicting.

Using the adaptation in the PR (you might prefer a different implementation, and I would suggest that max_stack is the default at least for EQTransformer) the final example above results in:

```
model.default_args["max_stack"] = True
chunk = st.slice(p_time - 40, p_time + 68)
cft = model.annotate(chunk)
fig_1 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_1.show()
```

![SNZO_P-40_overlapped_50s_maxstack](https://user-images.githubusercontent.com/10913395/173469077-4bf224d8-54a5-446b-991b-507b45a925f1.png)

I think that this gives a "better" result that is at least closer to what I think the original intention of EQTransformer was. In the examples below with a closer earthquake you can see that the degradation in prediction quality isn't just happening when events do not fully fit in the window used. These events use a short-period station in the SAMBA network:
```python
p_time = UTCDateTime(2008, 11, 11, 0, 57, 49, 324612) # rough P-arrival time, eyeballed
client = Client("IRIS")
st = client.get_waveforms(
    network="9F", station="EORO", location="*", channel="*",
    starttime=p_time - 360, endtime=p_time + 420)
st.detrend()

# First detect with P-arrival at 10-seconds into window
chunk = st.slice(p_time - 10, p_time + 50)
cft = model.annotate(chunk)
fig_1 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_1.suptitle('P at 10s')

# Try again with the P-arrival at 20-seconds
chunk = st.slice(p_time - 20, p_time + 40)
cft = model.annotate(chunk)
fig_2 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_2.suptitle('P at 20s')

# Try again with the P-arrival at 30-seconds
chunk = st.slice(p_time - 30, p_time + 30)
cft = model.annotate(chunk)
fig_3 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_3.suptitle('P at 30s')

# Try again with the P-arrival at 30-seconds
chunk = st.slice(p_time - 40, p_time + 20)
cft = model.annotate(chunk)
fig_4 = plot_predictions(chunk.select(component="Z")[0], cft, p_time)
fig_4.suptitle('P at 40s')
plt.show()
```

P-arrival 10s into window:
![EORO_P10](https://user-images.githubusercontent.com/10913395/173481426-40158a5f-ac52-4037-b46c-0badd9e2518b.png)

P-arrival 20s into window, degradation apparent:
![EORO_P20](https://user-images.githubusercontent.com/10913395/173481469-c5de11a3-7609-4de3-baeb-247c2da1f8c3.png)

P-arrival 30s into window, S-pick unlikely to be made. 
![EORO_P30](https://user-images.githubusercontent.com/10913395/173481540-133abd27-a124-4f88-b117-a56b13df8c3f.png)

P-arrival at 40s, detection would not be made, and no P or S picks.
![EORO_P40](https://user-images.githubusercontent.com/10913395/173481707-8a88469f-d4b2-4464-b74f-d57fe16d3fea.png)


---

## An aside on overlaps in EQTransformer

I ran into this when playing with overlaps - A student at VUW (Olivia) noticed that when she put her P arrivals in different places in her window for testing she got very different results and sometimes did not make a pick. This can be seen in the video below where a clear earthquake recorded at SAMBA site EORO is sometimes picked and sometimes missed when using an 18s overlap. Note that using the max-stack *does not* solve this issue because, depending on when your data start relative to the earthquake, there may never be a window that has the arrival in the optimal position. In the video below the data and predictions are as above, Each frame is the result of a prediction from a different chunk of data - each frame steps that by 5 seconds. A 120s window is used to ensure that multiple overlapping windows are used. The dashed lines are the thresholds of 0.5 and 0.3 suggested at one point in the EQTransformer paper.

https://user-images.githubusercontent.com/10913395/173469589-52bcdd63-72b2-4c07-b540-587702d498e2.mp4

The video below shows the same for a 30s overlap:

https://user-images.githubusercontent.com/10913395/173469643-00d9981c-393c-4078-b07f-750514eadc6a.mp4

And finally with a 55s overlap. In this example the frame step is 0.1s so the video is much slower, but this serves to show more realistically the variability in pick skill and quality based on uncontrollable event timing:

https://user-images.githubusercontent.com/10913395/173469659-c65688ed-a9b5-4cb1-85fe-f6fb25b6b1a8.mp4

Using the max-stack option creates a more stable result with the 55s overlap:

https://user-images.githubusercontent.com/10913395/173470036-56fad3bc-ac9f-4035-8e60-70609f5900d9.mp4





