### PR TITLE
Speedup nan trim

### DIFF
--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -1960,7 +1960,7 @@ class WaveformModel(SeisBenchModel, ABC):
         """
         mask = ~np.isnan(x)
         valid = np.nonzero(mask == True)[0]
-        mask[valid[0]:valid[-1]] = True
+        mask[valid[0] : valid[-1]] = True
         x = x[mask]
 
         return x, valid[0], len(x) - (1 + valid[-1])

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -1848,7 +1848,6 @@ class WaveformModel(SeisBenchModel, ABC):
                     },
                 )
             )
-
         return output
 
     def annotate_stream_pre(self, stream, argdict):
@@ -1865,6 +1864,7 @@ class WaveformModel(SeisBenchModel, ABC):
         :param argdict: Dictionary of arguments
         :return: Preprocessed stream
         """
+        # TODO: This should check for gaps and ensure that these are zeroed at the end of processing
         if self.filter_args is not None or self.filter_kwargs is not None:
             if self.filter_args is None:
                 filter_args = ()
@@ -1936,7 +1936,7 @@ class WaveformModel(SeisBenchModel, ABC):
         return pred
 
     @staticmethod
-    def _trim_nan(x):
+    def _trim_nan_old(x):
         """
         Removes all starting and trailing nan values from a 1D array and returns the new array and the number of NaNs
         removed per side.
@@ -1951,6 +1951,19 @@ class WaveformModel(SeisBenchModel, ABC):
         x = x[~mask_backward]
 
         return x, np.sum(mask_forward.astype(int)), np.sum(mask_backward.astype(int))
+
+    @staticmethod
+    def _trim_nan(x):
+        """
+        Removes all starting and trailing nan values from a 1D array and returns the new array and the number of NaNs
+        removed per side.
+        """
+        mask = ~np.isnan(x)
+        valid = np.nonzero(mask == True)[0]
+        mask[valid[0]:valid[-1]] = True
+        x = x[mask]
+
+        return x, valid[0], len(x) - (1 + valid[-1])
 
     def _recursive_torch_to_numpy(self, x):
         """

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -1961,9 +1961,10 @@ class WaveformModel(SeisBenchModel, ABC):
         mask = ~np.isnan(x)
         valid = np.nonzero(mask == True)[0]
         mask[valid[0] : valid[-1]] = True
+        _end = len(x)
         x = x[mask]
 
-        return x, valid[0], len(x) - (1 + valid[-1])
+        return x, valid[0], _end - (1 + valid[-1])
 
     def _recursive_torch_to_numpy(self, x):
         """

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -1936,23 +1936,6 @@ class WaveformModel(SeisBenchModel, ABC):
         return pred
 
     @staticmethod
-    def _trim_nan_old(x):
-        """
-        Removes all starting and trailing nan values from a 1D array and returns the new array and the number of NaNs
-        removed per side.
-        """
-        mask_forward = np.cumprod(np.isnan(x)).astype(
-            bool
-        )  # cumprod will be one until the first non-Nan value
-        x = x[~mask_forward]
-        mask_backward = np.cumprod(np.isnan(x)[::-1])[::-1].astype(
-            bool
-        )  # Double reverse for a backwards cumprod
-        x = x[~mask_backward]
-
-        return x, np.sum(mask_forward.astype(int)), np.sum(mask_backward.astype(int))
-
-    @staticmethod
     def _trim_nan(x):
         """
         Removes all starting and trailing nan values from a 1D array and returns the new array and the number of NaNs


### PR DESCRIPTION
This is a simple speed-up enhancement that speeds-up nan-trimming by about 4x on my machine. Trimming nan's at the start and end of predictions was one of the slower parts of the model workflow (taking about 0.15s for a day of 100 Hz data) - while this isn't that slow, this method runs in ~0.04s for the same data).