### PR TITLE
Documentation and validation for optional arguments for annotate/classify

### DIFF
--- a/docs/_ext/optional_argument_helper.py
+++ b/docs/_ext/optional_argument_helper.py
@@ -6,8 +6,6 @@ from docutils.parsers.rst import Directive
 from docutils import nodes
 from importlib import import_module
 
-# TODO: (In the base file and model files) Read defaults from _annotate_args instead of hardcoding them throughout the code
-
 
 class ArgsDirective(Directive):
     """
@@ -68,7 +66,7 @@ class ArgsDirective(Directive):
         tgroup += tbody
 
         caption = nodes.Text(
-            "The following parameters are available for the annotate/classify functions"
+            "The following parameters are available for the annotate/classify functions:"
         )
         remark = nodes.hint()
         remark += nodes.Text(

--- a/docs/_ext/optional_argument_helper.py
+++ b/docs/_ext/optional_argument_helper.py
@@ -1,0 +1,83 @@
+"""
+Directive for documenting optional arguments of WaveformModels
+"""
+
+from docutils.parsers.rst import Directive
+from docutils import nodes
+from importlib import import_module
+
+# TODO: (In the base file) Validate args passed to annotate
+
+
+class ArgsDirective(Directive):
+    """
+    Directive for writing out documentation
+    """
+
+    required_arguments = 2
+    optional_arguments = 0
+
+    def run(self):
+        mod, cls = self.arguments
+
+        cls = getattr(import_module(mod), cls)
+
+        annotate_args = cls._annotate_args
+
+        table = nodes.table()
+        tgroup = nodes.tgroup(cols=3)
+        tgroup.append(nodes.colspec(colwidth=1))  # Argument
+        tgroup.append(nodes.colspec(colwidth=2))  # Description
+        tgroup.append(nodes.colspec(colwidth=1))  # Default value
+        table += tgroup
+
+        thead = nodes.thead()
+        tgroup += thead
+        row = nodes.row()
+        entry = nodes.entry()
+        entry += nodes.paragraph(text="Argument")
+        row += entry
+        entry = nodes.entry()
+        entry += nodes.paragraph(text="Description")
+        row += entry
+        entry = nodes.entry()
+        entry += nodes.paragraph(text="Default value")
+        row += entry
+
+        thead.append(row)
+
+        rows = []
+        for key, value in annotate_args.items():
+            row = nodes.row()
+            rows.append(row)
+
+            entry = nodes.entry()
+            entry += nodes.paragraph(text=key)
+            row += entry
+
+            entry = nodes.entry()
+            entry += nodes.paragraph(text=str(value[0]))
+            row += entry
+
+            entry = nodes.entry()
+            entry += nodes.paragraph(text=str(value[1]))
+            row += entry
+
+        tbody = nodes.tbody()
+        tbody.extend(rows)
+        tgroup += tbody
+
+        caption = nodes.Text(
+            "The following parameters are available for the annotate/classify functions"
+        )
+        remark = nodes.hint()
+        remark += nodes.Text(
+            "Please note that the default parameters can be superseded by the pretrained "
+            "model weights. Check model.default_args to see which parameters are overwritten."
+        )
+
+        return [caption, table, remark]
+
+
+def setup(app):
+    app.add_directive("document_args", ArgsDirective)

--- a/docs/_ext/optional_argument_helper.py
+++ b/docs/_ext/optional_argument_helper.py
@@ -6,7 +6,7 @@ from docutils.parsers.rst import Directive
 from docutils import nodes
 from importlib import import_module
 
-# TODO: (In the base file) Validate args passed to annotate
+# TODO: (In the base file and model files) Read defaults from _annotate_args instead of hardcoding them throughout the code
 
 
 class ArgsDirective(Directive):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../"))
+sys.path.append(os.path.abspath("_ext"))
 
 # -- Project information -----------------------------------------------------
 
@@ -35,6 +36,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx_rtd_theme",
     "sphinx.ext.viewcode",
+    "optional_argument_helper",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/seisbench/models/aepicker.py
+++ b/seisbench/models/aepicker.py
@@ -10,6 +10,8 @@ class BasicPhaseAE(WaveformModel):
     Simple AutoEncoder network architecture to pick P-/S-phases,
     from Woollam et al., (2019).
 
+    .. document_args:: seisbench.models BasicPhaseAE
+
     :param in_channels: Number of input channels, by default 3.
     :type in_channels: int
     :param in_samples: Number of input samples per channel, by default 600.
@@ -23,6 +25,9 @@ class BasicPhaseAE(WaveformModel):
     :type sampling_rate: float
     :param kwargs: Keyword arguments passed to the constructor of :py:class:`WaveformModel`.
     """
+
+    _annotate_args = WaveformModel._annotate_args.copy()
+    _annotate_args["*_threshold"] = ("Detection threshold for the provided phase", 0.3)
 
     def __init__(
         self, in_channels=3, classes=3, phases="NPS", sampling_rate=100, **kwargs

--- a/seisbench/models/aepicker.py
+++ b/seisbench/models/aepicker.py
@@ -127,7 +127,9 @@ class BasicPhaseAE(WaveformModel):
 
             picks += self.picks_from_annotations(
                 annotations.select(channel=f"BasicPhaseAE_{phase}"),
-                argdict.get(f"{phase}_threshold", 0.3),
+                argdict.get(
+                    f"{phase}_threshold", self._annotate_args.get("*_threshold")[1]
+                ),
                 phase,
             )
 

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -958,7 +958,7 @@ class WaveformModel(SeisBenchModel, ABC):
         argdict["sampling_rate"] = groups[0][0].stats.sampling_rate
 
         # Queues for multiprocessing
-        batch_size = argdict.get("batch_size", 64)
+        batch_size = argdict.get("batch_size", self._annotate_args.get("batch_size")[1])
         queue_groups = asyncio.Queue()  # Waveform groups
         queue_raw_blocks = (
             asyncio.Queue()
@@ -1080,7 +1080,7 @@ class WaveformModel(SeisBenchModel, ABC):
         self.cpu()
 
         # Queues for multiprocessing
-        batch_size = argdict.get("batch_size", 64)
+        batch_size = argdict.get("batch_size", self._annotate_args.get("batch_size")[1])
 
         queue_groups = torchmp.JoinableQueue()  # Waveform groups
         queue_raw_blocks = (
@@ -1293,7 +1293,7 @@ class WaveformModel(SeisBenchModel, ABC):
         :return: None
         """
         buffer = []
-        batch_size = argdict.get("batch_size", 64)
+        batch_size = argdict.get("batch_size", self._annotate_args.get("batch_size")[1])
 
         elem = await queue_in.get()
         while True:
@@ -1427,7 +1427,7 @@ class WaveformModel(SeisBenchModel, ABC):
         :param argdict:
         :return:
         """
-        stride = argdict.get("stride", 1)
+        stride = argdict.get("stride", self._annotate_args.get("stride")[1])
         starts = np.arange(0, block.shape[1] - self.in_samples + 1, stride)
         if len(starts) == 0:
             seisbench.logger.warning(
@@ -1485,7 +1485,7 @@ class WaveformModel(SeisBenchModel, ABC):
         """
         Reassembles point predictions into numpy arrays. Returns None except if a buffer was processed.
         """
-        stride = argdict.get("stride", 1)
+        stride = argdict.get("stride", self._annotate_args.get("stride")[1])
 
         window, metadata = elem
         t0, s, len_starts, trace_stats, bucket_id = metadata
@@ -1546,7 +1546,7 @@ class WaveformModel(SeisBenchModel, ABC):
         """
         Cuts numpy arrays into fragments for array prediction models.
         """
-        overlap = argdict.get("overlap", 0)
+        overlap = argdict.get("overlap", self._annotate_args.get("overlap")[1])
 
         t0, block, trace_stats = elem
 
@@ -1621,9 +1621,9 @@ class WaveformModel(SeisBenchModel, ABC):
         """
         Reassembles array predictions into numpy arrays.
         """
-        overlap = argdict.get("overlap", 0)
+        overlap = argdict.get("overlap", self._annotate_args.get("overlap")[1])
         stack_method = argdict.get(
-            "stacking", "max"
+            "stacking", self._annotate_args.get("stacking")[1]
         ).lower()  # This is a breaking change for v 0.3 - see PR#99
         assert (
             stack_method in self._stack_options
@@ -1734,7 +1734,7 @@ class WaveformModel(SeisBenchModel, ABC):
             self.to(device)
 
         buffer = []
-        batch_size = argdict.get("batch_size", 64)
+        batch_size = argdict.get("batch_size", self._annotate_args.get("batch_size")[1])
 
         while True:
             elem = queue_in.get()

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -644,6 +644,8 @@ class WaveformModel(SeisBenchModel, ABC):
 
     For details see the documentation of these functions.
 
+    .. document_args:: seisbench.models WaveformModel
+
     :param component_order: Specify component order (e.g. ['ZNE']), defaults to None.
     :type component_order: list, optional
     :param sampling_rate: Sampling rate of the model, defaults to None.
@@ -686,6 +688,21 @@ class WaveformModel(SeisBenchModel, ABC):
     :type grouping: str
     :param kwargs: Kwargs are passed to the superclass
     """
+
+    # Optional arguments for annotate/classify: key -> (documentation, default_value)
+    _annotate_args = {
+        "batch_size": ("Batch size for the model", 64),
+        "overlap": (
+            "Overlap between prediction windows in samples (only for window prediction models)",
+            0,
+        ),
+        "stacking": (
+            "Stacking method for overlapping windows (only for window prediction models). "
+            "Options are 'max' and 'avg'. ",
+            "max",
+        ),
+        "stride": ("Stride in samples (only for point prediction models)", 1),
+    }
 
     _stack_options = {
         "avg",

--- a/seisbench/models/cred.py
+++ b/seisbench/models/cred.py
@@ -11,7 +11,12 @@ class CRED(WaveformModel):
     """
     Note: There are subtle differences between the model presented in the paper (as in Figure 1) and the code on Github.
           Here we follow the implementation from Github to allow for compatibility with the pretrained weights.
+
+    .. document_args:: seisbench.models CRED
     """
+
+    _annotate_args = WaveformModel._annotate_args.copy()
+    _annotate_args["detection_threshold"] = ("Detection threshold", 0.5)
 
     def __init__(
         self,

--- a/seisbench/models/cred.py
+++ b/seisbench/models/cred.py
@@ -130,7 +130,9 @@ class CRED(WaveformModel):
         """
         detections = self.detections_from_annotations(
             annotations.select(channel="CRED_Detection"),
-            argdict.get("detection_threshold", 0.5),
+            argdict.get(
+                "detection_threshold", self._annotate_args.get("detection_threshold")[1]
+            ),
         )
 
         return detections

--- a/seisbench/models/eqtransformer.py
+++ b/seisbench/models/eqtransformer.py
@@ -10,13 +10,15 @@ import warnings
 # For implementation, potentially follow: https://medium.com/huggingface/from-tensorflow-to-pytorch-265f40ef2a28
 class EQTransformer(WaveformModel):
     """
-    The EQTranformer from Mousavi et al. (2020)
+    The EQTransformer from Mousavi et al. (2020)
 
     Implementation adapted from the Github repository https://github.com/smousavi05/EQTransformer
     Assumes padding="same" and activation="relu" as in the pretrained EQTransformer models
 
     By instantiating the model with `from_pretrained("original")` a binary compatible version of the original
     EQTransformer with the original weights from Mousavi et al. (2020) can be loaded.
+
+    .. document_args:: seisbench.models EQTransformer
 
     :param in_channels: Number of input channels, by default 3.
     :param in_samples: Number of input samples per channel, by default 6000.
@@ -34,6 +36,14 @@ class EQTransformer(WaveformModel):
                                 The exception is when loading the original weights using :py:func:`from_pretrained`.
     :param kwargs: Keyword arguments passed to the constructor of :py:class:`WaveformModel`.
     """
+
+    _annotate_args = WaveformModel._annotate_args.copy()
+    _annotate_args["*_threshold"] = ("Detection threshold for the provided phase", 0.1)
+    _annotate_args["detection_threshold"] = ("Detection threshold", 0.3)
+    _annotate_args["blinding"] = (
+        "Number of prediction samples to discard on each side of each window prediction",
+        (0, 0),
+    )
 
     def __init__(
         self,

--- a/seisbench/models/eqtransformer.py
+++ b/seisbench/models/eqtransformer.py
@@ -242,7 +242,9 @@ class EQTransformer(WaveformModel):
 
     def annotate_window_post(self, pred, piggyback=None, argdict=None):
         # Combine predictions in one array
-        prenan, postnan = argdict.get("blinding", (0, 0))
+        prenan, postnan = argdict.get(
+            "blinding", self._annotate_args.get("blinding")[1]
+        )
         pred = np.stack(pred, axis=-1)
         if prenan > 0:
             pred[:prenan] = np.nan
@@ -285,13 +287,17 @@ class EQTransformer(WaveformModel):
         for phase in self.phases:
             picks += self.picks_from_annotations(
                 annotations.select(channel=f"EQTransformer_{phase}"),
-                argdict.get(f"{phase}_threshold", 0.1),
+                argdict.get(
+                    f"{phase}_threshold", self._annotate_args.get("*_threshold")[1]
+                ),
                 phase,
             )
 
         detections = self.detections_from_annotations(
             annotations.select(channel="EQTransformer_Detection"),
-            argdict.get("detection_threshold", 0.3),
+            argdict.get(
+                "detection_threshold", self._annotate_args.get("detection_threshold")[1]
+            ),
         )
 
         return sorted(picks), sorted(detections)

--- a/seisbench/models/gpd.py
+++ b/seisbench/models/gpd.py
@@ -125,7 +125,9 @@ class GPD(WaveformModel):
 
             picks += self.picks_from_annotations(
                 annotations.select(channel=f"GPD_{phase}"),
-                argdict.get(f"{phase}_threshold", 0.7),
+                argdict.get(
+                    f"{phase}_threshold", self._annotate_args.get("*_threshold")[1]
+                ),
                 phase,
             )
 

--- a/seisbench/models/gpd.py
+++ b/seisbench/models/gpd.py
@@ -6,6 +6,13 @@ import numpy as np
 
 
 class GPD(WaveformModel):
+    """
+    .. document_args:: seisbench.models GPD
+    """
+
+    _annotate_args = WaveformModel._annotate_args.copy()
+    _annotate_args["*_threshold"] = ("Detection threshold for the provided phase", 0.7)
+
     def __init__(
         self,
         in_channels=3,

--- a/seisbench/models/phasenet.py
+++ b/seisbench/models/phasenet.py
@@ -6,6 +6,13 @@ import numpy as np
 
 
 class PhaseNet(WaveformModel):
+    """
+    .. document_args:: seisbench.models PhaseNet
+    """
+
+    _annotate_args = WaveformModel._annotate_args.copy()
+    _annotate_args["*_threshold"] = ("Detection threshold for the provided phase", 0.3)
+
     def __init__(
         self, in_channels=3, classes=3, phases="NPS", sampling_rate=100, **kwargs
     ):

--- a/seisbench/models/phasenet.py
+++ b/seisbench/models/phasenet.py
@@ -129,7 +129,9 @@ class PhaseNet(WaveformModel):
 
             picks += self.picks_from_annotations(
                 annotations.select(channel=f"PhaseNet_{phase}"),
-                argdict.get(f"{phase}_threshold", 0.3),
+                argdict.get(
+                    f"{phase}_threshold", self._annotate_args.get("*_threshold")[1]
+                ),
                 phase,
             )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1878,3 +1878,35 @@ def test_list_pretrained_version_empty_cache(tmp_path):
         "seisbench.cache_root", tmp_path / "list_versions"
     ):  # Ensure SeisBench cache is empty
         seisbench.models.GPD.list_versions("original", remote=False)
+
+
+def test_verify_argdict(caplog):
+    model = seisbench.models.GPD()
+
+    # No wildcard - Matching
+    model._annotate_args = {"param": ("", 0)}
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        model._verify_argdict({"param": 3})
+    assert caplog.text == ""
+
+    # Wildcard - Matching
+    model._annotate_args = {"*_param": ("", 0)}
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        model._verify_argdict({"my_param": 3})
+    assert caplog.text == ""
+
+    # No wildcard - Not matching
+    model._annotate_args = {"param": ("", 0)}
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        model._verify_argdict({"not_param": 3})
+    assert "Unknown argument" in caplog.text
+
+    # Wildcard - Not matching
+    model._annotate_args = {"*_param": ("", 0)}
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        model._verify_argdict({"my_var": 3})
+    assert "Unknown argument" in caplog.text


### PR DESCRIPTION
This PR cleans up the optional arguments for `annotate/classify` and their documentation. It contains three contributions:

- A Sphinx extension to automatically document all optional arguments.
- A parameter validation for the optional arguments. Any unknown argument passed to `annotate/classify` will raise a warning.
- Default values for all parameters are now defined centrally in the `_annotate_args` dictionary instead as scattered throughout the code.

Closes #100