### PR TITLE
Add data grouping

### DIFF
--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -1094,9 +1094,17 @@ class WaveformDataset:
             metadata.append(trace_meta)
 
         if return_metadata:
-            return waveforms, metadata
+            return waveforms, WaveformDataset._pack_metadata(metadata)
         else:
             return waveforms
+
+    @staticmethod
+    def _pack_metadata(metadata):
+        """
+        Reformats a list of dict into a dict of lists. Assumes identical keys in all dicts!
+        """
+
+        return {key: [m[key] for m in metadata] for key in metadata[0].keys()}
 
     def _verify_grouping_defined(self):
         """
@@ -1839,7 +1847,6 @@ class MultiWaveformDataset:
     get_group_waveforms = WaveformDataset.get_group_waveforms
     get_group_samples = WaveformDataset.get_group_samples
     get_group_size = WaveformDataset.get_group_size
-    get_group_idx_from_params = WaveformDataset.get_group_idx_from_params
     _get_group_internal = WaveformDataset._get_group_internal
 
 

--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -1534,8 +1534,13 @@ class MultiWaveformDataset:
     @property
     def grouping(self):
         """
-        The grouping parameters for the dataset. These parameters are used to determine the
-        :py:attr:`~groups` and for the associated methods.
+        The grouping parameters for the dataset.
+        Grouping allows to access metadata and waveforms
+        jointly from a set of traces with a common metadata parameter.
+        This can for example be used to access all waveforms belong to one event
+        and building event based models.
+        Setting the grouping parameter defines the output of
+        :py:attr:`~groups` and the associated methods.
         `grouping` can be either a single string or a list of strings.
         Each string must be a column in the metadata.
         By default, the grouping is None.

--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -146,6 +146,8 @@ class WaveformDataset:
 
         self._waveform_cache = defaultdict(dict)
 
+        self.grouping = None
+
     def __str__(self):
         return f"{self._name} - {len(self)} traces"
 
@@ -287,6 +289,39 @@ class WaveformDataset:
                 )
 
         self._component_order = value
+
+    @property
+    def grouping(self):
+        """
+        The grouping parameters for the dataset. These parameters are used to determine the
+        :py:attr:`~groups` and for the associated methods.
+        `grouping` can be either a single string or a list of strings.
+        Each string must be a column in the metadata.
+        By default, the grouping is None.
+        """
+        return self._grouping
+
+    @grouping.setter
+    def grouping(self, value):
+        self._grouping = value
+        if value is None:
+            self._groups = None
+            self._groups_to_trace_idx = None
+        else:
+            self._groups_to_trace_idx = self.metadata.groupby(value).groups
+            self._groups = list(self._groups_to_trace_idx.keys())
+            self._groups_to_group_idx = {
+                group: i for i, group in enumerate(self._groups)
+            }
+
+    @property
+    def groups(self):
+        """
+        The list of groups as defined by the :py:attr:`~grouping` or `None` if :py:attr:`~grouping` is `None`.
+        """
+        return copy.copy(
+            self._groups
+        )  # Return a copy to make the internal groups immutable
 
     @property
     def chunks(self):
@@ -599,6 +634,22 @@ class WaveformDataset:
                     "Component order not specified in data set. "
                     "Keeping original components."
                 )
+
+    def get_group_idx_from_params(self, params):
+        """
+        Returns the index of the group identified by the params.
+
+        :param params: The parameters identifying the group. For a single grouping parameter, this argument will be a
+                       single value. Otherwise this argument needs to be a tuple of keys.
+        :return: Index of the group
+        :rtype: int
+        """
+        self._verify_grouping_defined()
+
+        if params in self._groups_to_group_idx:
+            return self._groups_to_group_idx[params]
+        else:
+            raise KeyError("The dataset does not contain the requested group.")
 
     def get_idx_from_trace_name(self, trace_name, chunk=None, dataset=None):
         """
@@ -990,6 +1041,72 @@ class WaveformDataset:
 
         return waveforms
 
+    def get_group_size(self, idx):
+        """
+        Returns the number of samples in a group
+
+        :param idx: Group index
+        :type idx: int
+        :return: Size of the group
+        :rtype: int
+        """
+        self._verify_grouping_defined()
+        group = self.groups[idx]
+        idx = self._groups_to_trace_idx[group]
+        return len(idx)
+
+    def get_group_samples(self, idx, **kwargs):
+        """
+        Returns the waveforms and metadata for each member of a group.
+        For details see :py:func:`get_sample`.
+
+        :param idx: Group index
+        :type idx: int
+        :param kwargs: Kwargs passed to :py:func:`get_sample`
+        :return: List of waveforms, list of metadata dicts
+        """
+        return self._get_group_internal(idx, return_metadata=True, **kwargs)
+
+    def get_group_waveforms(self, idx, **kwargs):
+        """
+        Returns the waveforms for each member of a group.
+        For details see :py:func:`get_sample`.
+
+        :param idx: Group index
+        :type idx: int
+        :param kwargs: Kwargs passed to :py:func:`get_sample`
+        :return: List of waveforms
+        """
+        return self._get_group_internal(idx, return_metadata=False, **kwargs)
+
+    def _get_group_internal(self, idx, return_metadata, **kwargs):
+        self._verify_grouping_defined()
+
+        group = self.groups[idx]
+        idx = self._groups_to_trace_idx[group]
+
+        waveforms = []
+        metadata = []
+
+        for trace_idx in idx:
+            trace_wv, trace_meta = self.get_sample(trace_idx, **kwargs)
+            waveforms.append(trace_wv)
+            metadata.append(trace_meta)
+
+        if return_metadata:
+            return waveforms, metadata
+        else:
+            return waveforms
+
+    def _verify_grouping_defined(self):
+        """
+        Check if grouping is defined and raises and error otherwise
+        """
+        if self.grouping is None:
+            raise ValueError(
+                "Groups need to be defined first by assigning a value to grouping."
+            )
+
     def _get_single_waveform(
         self,
         trace_name,
@@ -1323,6 +1440,8 @@ class MultiWaveformDataset:
         )
 
         self._homogenize_dataformat(datasets)
+        self._grouping = None
+        self._homogenize_grouping(datasets)
         self._build_trace_name_to_idx_dict()
 
     def __add__(self, other):
@@ -1392,6 +1511,49 @@ class MultiWaveformDataset:
                 f"Using missing_components from first dataset ({self.datasets[0].missing_components})."
             )
             self.missing_components = self.datasets[0].missing_components
+
+    def _homogenize_grouping(self, datasets):
+        groupings = [dataset.grouping for dataset in datasets]
+        if any(grouping != groupings[0] for grouping in groupings):
+            seisbench.logger.warning(
+                "Found inconsistent groupings. Setting grouping to None."
+            )
+            self.grouping = None
+        else:
+            self.grouping = groupings[0]
+
+    @property
+    def grouping(self):
+        """
+        The grouping parameters for the dataset. These parameters are used to determine the
+        :py:attr:`~groups` and for the associated methods.
+        `grouping` can be either a single string or a list of strings.
+        Each string must be a column in the metadata.
+        By default, the grouping is None.
+        """
+        return self._grouping
+
+    @grouping.setter
+    def grouping(self, value):
+        self._grouping = value
+        if value is None:
+            self._groups = None
+            self._groups_to_trace_idx = None
+        else:
+            self._groups_to_trace_idx = self.metadata.groupby(value).groups
+            self._groups = list(self._groups_to_trace_idx.keys())
+            self._groups_to_group_idx = {
+                group: i for i, group in enumerate(self._groups)
+            }
+
+    @property
+    def groups(self):
+        """
+        The list of groups as defined by the :py:attr:`~grouping` or `None` if :py:attr:`~grouping` is `None`.
+        """
+        return copy.copy(
+            self._groups
+        )  # Return a copy to make the internal groups immutable
 
     @property
     def datasets(self):
@@ -1672,6 +1834,13 @@ class MultiWaveformDataset:
     train_dev_test = WaveformDataset.train_dev_test
     _build_trace_name_to_idx_dict = WaveformDataset._build_trace_name_to_idx_dict
     get_idx_from_trace_name = WaveformDataset.get_idx_from_trace_name
+    get_group_idx_from_params = WaveformDataset.get_group_idx_from_params
+    _verify_grouping_defined = WaveformDataset._verify_grouping_defined
+    get_group_waveforms = WaveformDataset.get_group_waveforms
+    get_group_samples = WaveformDataset.get_group_samples
+    get_group_size = WaveformDataset.get_group_size
+    get_group_idx_from_params = WaveformDataset.get_group_idx_from_params
+    _get_group_internal = WaveformDataset._get_group_internal
 
 
 class LoadingContext:

--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -776,6 +776,7 @@ class WaveformDataset:
             self._metadata = self._metadata[mask]
             self._evict_cache()
             self._build_trace_name_to_idx_dict()
+            self.grouping = self.grouping  # Recalculate grouping
         else:
             other = self.copy()
             other.filter(mask, inplace=True)
@@ -1775,6 +1776,7 @@ class MultiWaveformDataset:
             # Calculate new metadata
             self._metadata = pd.concat(x.metadata for x in self.datasets)
             self._build_trace_name_to_idx_dict()
+            self.grouping = self.grouping  # Rebuild groups
 
         else:
             return MultiWaveformDataset(

--- a/seisbench/generate/__init__.py
+++ b/seisbench/generate/__init__.py
@@ -1,4 +1,4 @@
-from .generator import GenericGenerator, SteeredGenerator
+from .generator import GenericGenerator, SteeredGenerator, GroupGenerator
 from .augmentation import (
     Normalize,
     Filter,

--- a/seisbench/generate/__init__.py
+++ b/seisbench/generate/__init__.py
@@ -27,4 +27,5 @@ from .windows import (
     WindowAroundSample,
     RandomWindow,
     SteeredWindow,
+    AlignGroupsOnKey,
 )

--- a/seisbench/generate/__init__.py
+++ b/seisbench/generate/__init__.py
@@ -29,4 +29,5 @@ from .windows import (
     SteeredWindow,
     AlignGroupsOnKey,
     UTCOffsets,
+    SelectOrPadAlongAxis,
 )

--- a/seisbench/generate/__init__.py
+++ b/seisbench/generate/__init__.py
@@ -28,4 +28,5 @@ from .windows import (
     RandomWindow,
     SteeredWindow,
     AlignGroupsOnKey,
+    UTCOffsets,
 )

--- a/seisbench/generate/augmentation.py
+++ b/seisbench/generate/augmentation.py
@@ -135,7 +135,11 @@ class Copy:
 class Filter:
     """
     Implements a filter augmentation, closely based on scipy.signal.butter.
-    Please refer to the scipy documentation for more detailed description of the parameters
+    Please refer to the scipy documentation for more detailed description of the parameters.
+
+    The filter can also be applied to unaligned groups, i.e., lists of numpy arrays. The list is not taken into
+    account for the enumeration of the axis, i.e., `axis=0` will refer to the first axis in every array within
+    the list.
 
     :param N: Filter order
     :type N: int
@@ -173,24 +177,32 @@ class Filter:
         x, metadata = state_dict[self.key[0]]
 
         sampling_rate = metadata["trace_sampling_rate_hz"]
-        if isinstance(sampling_rate, (list, tuple, np.ndarray)):
-            if not np.allclose(sampling_rate, sampling_rate[0]):
-                raise NotImplementedError(
-                    "Found mixed sampling rates in filter. "
-                    "Filter currently only works on consistent sampling rates."
-                )
-            else:
-                sampling_rate = sampling_rate[0]
+        if isinstance(x, list):
+            x = [self._filter_trace(y, sr) for y, sr in zip(x, sampling_rate)]
+        else:
+            if isinstance(sampling_rate, (list, tuple, np.ndarray)):
+                if not np.allclose(sampling_rate, sampling_rate[0]):
+                    raise NotImplementedError(
+                        "Found mixed sampling rates in filter. "
+                        "Filter currently only works on consistent sampling rates or for unaligned groups of traces."
+                    )
+                else:
+                    sampling_rate = sampling_rate[0]
 
+            x = self._filter_trace(x, sampling_rate)
+
+        state_dict[self.key[1]] = (x, metadata)
+
+    def _filter_trace(self, x, sampling_rate):
         sos = scipy.signal.butter(*self._filt_args, output="sos", fs=sampling_rate)
+
         if self.forward_backward:
             # Copy is required, because otherwise the stride of x is negative.T
             # This can break the pytorch collate function.
             x = scipy.signal.sosfiltfilt(sos, x, axis=self.axis).copy()
         else:
             x = scipy.signal.sosfilt(sos, x, axis=self.axis)
-
-        state_dict[self.key[1]] = (x, metadata)
+        return x
 
     def __str__(self):
         N, Wn, btype, analog = self._filt_args

--- a/seisbench/generate/augmentation.py
+++ b/seisbench/generate/augmentation.py
@@ -7,6 +7,10 @@ class Normalize:
     """
     A normalization augmentation that allows demeaning, detrending and amplitude normalization (in this order).
 
+    The normalization can also be applied to unaligned groups, i.e., lists of numpy arrays. The list is not taken into
+    account for the enumeration of the axis, i.e., `demean_axis=0` will refer to the first axis in every array within
+    the list.
+
     :param demean_axis: The axis (single axis or tuple) which should be jointly demeaned.
                         None indicates no demeaning.
     :type demean_axis: int, None
@@ -56,9 +60,14 @@ class Normalize:
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key[0]]
 
-        x = self._demean(x)
-        x = self._detrend(x)
-        x = self._amp_norm(x)
+        if isinstance(x, list):
+            x = [self._demean(y) for y in x]
+            x = [self._detrend(y) for y in x]
+            x = [self._amp_norm(y) for y in x]
+        else:
+            x = self._demean(x)
+            x = self._detrend(x)
+            x = self._amp_norm(x)
 
         state_dict[self.key[1]] = (x, metadata)
 

--- a/seisbench/generate/windows.py
+++ b/seisbench/generate/windows.py
@@ -691,7 +691,7 @@ class UTCOffsets:
 class SelectOrPadAlongAxis:
     """
     Changes the length of an axis from `m` to `n` by:
-    - padding if `m` < `n`
+    - padding/repeating data if `m` < `n`
     - random selection if `m` > `n`
 
     In addition, can adjust the length of the metadata arrays accordingly. This augmentation is primarily intended to
@@ -703,8 +703,10 @@ class SelectOrPadAlongAxis:
     :type n: int
     :param adjust_metadata: If true, adjusts metadata. Otherwise, leaves metadata unaltered.
     :type adjust_metadata: None
+    :param repeat: If true, repeat data instead of padding
+    :type repeat: bool
     :param axis: Axis along which reshaping should be applied
-    :type axis: None
+    :type axis: int
     :param key: The keys for reading from and writing to the state dict.
                 If key is a single string, the corresponding entry in state dict is modified.
                 Otherwise, a 2-tuple is expected, with the first string indicating the key to
@@ -712,9 +714,10 @@ class SelectOrPadAlongAxis:
     :type key: str, tuple[str, str]
     """
 
-    def __init__(self, n, adjust_metadata=True, axis=0, key="X"):
+    def __init__(self, n, adjust_metadata=True, repeat=True, axis=0, key="X"):
         self.n = n
         self.adjust_metadata = adjust_metadata
+        self.repeat = repeat
         self.axis = axis
 
         if isinstance(key, str):
@@ -734,6 +737,8 @@ class SelectOrPadAlongAxis:
 
         if x.shape[self.axis] <= self.n:
             idx = np.arange(x.shape[self.axis])
+            if self.repeat:
+                idx = np.tile(idx, self.n)[: self.n]
         else:
             idx = np.arange(x.shape[self.axis])
             np.random.shuffle(idx)

--- a/seisbench/generate/windows.py
+++ b/seisbench/generate/windows.py
@@ -1,3 +1,5 @@
+import warnings
+
 import seisbench
 
 import copy
@@ -250,11 +252,13 @@ class WindowAroundSample(FixedWindow):
 
     def __call__(self, state_dict, windowlen=None):
         _, metadata = state_dict[self.key[0]]
-        cand = [
-            metadata[key]
-            for key in self.metadata_keys
-            if key in metadata and not np.isnan(metadata[key])
-        ]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Mean of empty slice")
+            cand = [
+                np.nanmean(metadata[key])
+                for key in self.metadata_keys
+                if key in metadata and not np.isnan(np.nanmean(metadata[key]))
+            ]
 
         if len(cand) == 0:
             cand = [self.samples_before]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1332,11 +1332,41 @@ def grouping_test_data():
 
     data._metadata = pd.DataFrame(
         [
-            {"event": "a", "station": "A", "part": 0},
-            {"event": "b", "station": "A", "part": 0},
-            {"event": "b", "station": "B", "part": 0},
-            {"event": "b", "station": "C", "part": 0},
-            {"event": "b", "station": "C", "part": 1},
+            {
+                "event": "a",
+                "station": "A",
+                "part": 0,
+                "trace_name": "a1",
+                "trace_chunk": "",
+            },
+            {
+                "event": "b",
+                "station": "A",
+                "part": 0,
+                "trace_name": "b1",
+                "trace_chunk": "",
+            },
+            {
+                "event": "b",
+                "station": "B",
+                "part": 0,
+                "trace_name": "b2",
+                "trace_chunk": "",
+            },
+            {
+                "event": "b",
+                "station": "C",
+                "part": 0,
+                "trace_name": "b3",
+                "trace_chunk": "",
+            },
+            {
+                "event": "b",
+                "station": "C",
+                "part": 1,
+                "trace_name": "b4",
+                "trace_chunk": "",
+            },
         ]
     )
     return data
@@ -1388,3 +1418,12 @@ def test_multiwaveformdataset_grouping():
     data.get_group_waveforms(0)
     data.get_group_samples(0)
     data.get_group_idx_from_params(data.metadata.iloc[0]["source_magnitude"])
+
+
+def test_grouping_filter(grouping_test_data):
+    data = grouping_test_data
+
+    data.grouping = "event"
+    mask = data.metadata["event"] == "b"
+    data.filter(mask, inplace=True)
+    assert len(data.groups) == 1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1365,12 +1365,12 @@ def test_get_group_sample_waveforms(grouping_test_data):
     idx = data.get_group_idx_from_params("b")
 
     with patch("seisbench.data.WaveformDataset.get_sample") as get_sample:
-        get_sample.return_value = (np.zeros(5), {})
+        get_sample.return_value = (np.zeros(5), {"a": 1})
 
         waveforms, metadata = data.get_group_samples(idx)
-        assert len(waveforms) == len(metadata) == 4
+        assert len(waveforms) == len(metadata["a"]) == 4
+        assert metadata == {"a": [1, 1, 1, 1]}
         assert isinstance(waveforms[0], np.ndarray)
-        assert metadata[0] == {}
 
         waveforms = data.get_group_waveforms(idx)
         assert len(waveforms) == 4

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1309,43 +1309,82 @@ def test_chunked_datasets_key_collision(tmp_path):
     assert (data.get_waveforms(1) == 1).all()
 
 
-def test_component_mapping_fix_for_implicit_int_casts(tmp_path: Path):
+def test_verify_grouping():
+    data = seisbench.data.DummyDataset()
 
-    # The following implicit calls of seisbench.data.WaveformDataset._get_component_mapping() no longer raise
+    data.grouping = None
+    with pytest.raises(ValueError):
+        data.get_group_idx_from_params("dummy")
 
-    # Example values to combine
-    check_co_vals = ["ZNE", "Z12", "12", "Z12", "Z12H"]
-    for source_co in check_co_vals:
-        for target_co in check_co_vals:
-            data_path = tmp_path / "writer_a"
-            with seisbench.data.WaveformDataWriter(
-                data_path / "metadata.csv", data_path / "waveforms.hdf5"
-            ) as writer:
-                trace = {"trace_name": "dummy"}
-                writer.add_trace(trace, np.zeros((3, 100)))
-                writer.data_format["component_order"] = source_co
-            # Seisbench will call _get_component_mapping() in order to calculate possibly missing components
-            seisbench.data.WaveformDataset(data_path, component_order=target_co)
+    with pytest.raises(ValueError):
+        data.get_group_size(0)
 
-    # None of these test values should should be a problem
-    for test_val in [1, 12, "1", "12", "12H", "Z12H"]:
-        data_path = tmp_path / "writer_b"
-        with seisbench.data.WaveformDataWriter(
-            data_path / "metadata.csv", data_path / "waveforms.hdf5"
-        ) as writer:
-            # A trace with component order different to the one passed to the dataset init call
-            trace = {"trace_name": "dummy", "trace_component_order": test_val}
-            writer.add_trace(trace, np.zeros((3, 100)))
-        # Seisbench will check each trace for missing components compared with the passed component order
-        seisbench.data.WaveformDataset(data_path, component_order="Z12")
+    with pytest.raises(ValueError):
+        data.get_group_samples(0)
 
-    # Missing trace_component_order entries should raise
-    for test_val in ["", np.nan]:
-        data_path = tmp_path / "writer_c"
-        with seisbench.data.WaveformDataWriter(
-            data_path / "metadata.csv", data_path / "waveforms.hdf5"
-        ) as writer:
-            trace = {"trace_name": "dummy", "trace_component_order": test_val}
-            writer.add_trace(trace, np.zeros((3, 100)))
-        with pytest.raises(ValueError):
-            seisbench.data.WaveformDataset(data_path, component_order="Z12")
+    with pytest.raises(ValueError):
+        data.get_group_waveforms(0)
+
+
+@pytest.fixture
+def grouping_test_data():
+    data = seisbench.data.DummyDataset()
+
+    data._metadata = pd.DataFrame(
+        [
+            {"event": "a", "station": "A", "part": 0},
+            {"event": "b", "station": "A", "part": 0},
+            {"event": "b", "station": "B", "part": 0},
+            {"event": "b", "station": "C", "part": 0},
+            {"event": "b", "station": "C", "part": 1},
+        ]
+    )
+    return data
+
+
+def test_get_group_size(grouping_test_data):
+    data = grouping_test_data
+
+    data.grouping = "event"
+    assert len(data.groups) == 2
+    assert data.get_group_size(data.get_group_idx_from_params("a")) == 1
+    assert data.get_group_size(data.get_group_idx_from_params("b")) == 4
+
+    data.grouping = ["event", "station"]
+    assert len(data.groups) == 4
+    assert data.get_group_size(data.get_group_idx_from_params(("a", "A"))) == 1
+    assert data.get_group_size(data.get_group_idx_from_params(("b", "A"))) == 1
+    assert data.get_group_size(data.get_group_idx_from_params(("b", "B"))) == 1
+    assert data.get_group_size(data.get_group_idx_from_params(("b", "C"))) == 2
+
+
+def test_get_group_sample_waveforms(grouping_test_data):
+    data = grouping_test_data
+
+    data.grouping = "event"
+    idx = data.get_group_idx_from_params("b")
+
+    with patch("seisbench.data.WaveformDataset.get_sample") as get_sample:
+        get_sample.return_value = (np.zeros(5), {})
+
+        waveforms, metadata = data.get_group_samples(idx)
+        assert len(waveforms) == len(metadata) == 4
+        assert isinstance(waveforms[0], np.ndarray)
+        assert metadata[0] == {}
+
+        waveforms = data.get_group_waveforms(idx)
+        assert len(waveforms) == 4
+        assert isinstance(waveforms[0], np.ndarray)
+
+
+def test_multiwaveformdataset_grouping():
+    # Mostly checks that nothing crashes
+    data = seisbench.data.DummyDataset() + seisbench.data.DummyDataset()
+
+    data.grouping = "source_magnitude"
+
+    assert len(data.groups) == 97
+    assert data.get_group_size(0) == 2
+    data.get_group_waveforms(0)
+    data.get_group_samples(0)
+    data.get_group_idx_from_params(data.metadata.iloc[0]["source_magnitude"])

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -190,6 +190,38 @@ def test_filter_sampling_rate_list():
         filt(state_dict)
 
 
+def test_filter_unaligned_group():
+    filt = Filter(2, 1, "lowpass")
+
+    # Identical sampling rate
+    state_dict = {
+        "X": (
+            [np.random.rand(3, 1000), np.random.rand(3, 2000)],
+            {"trace_sampling_rate_hz": [20, 20]},
+        )
+    }
+    filt(state_dict)
+
+    # Just sanity checks
+    assert len(state_dict["X"][0]) == 2
+    assert state_dict["X"][0][0].shape == (3, 1000)
+    assert state_dict["X"][0][1].shape == (3, 2000)
+
+    # Mixed sampling rate
+    state_dict = {
+        "X": (
+            [np.random.rand(3, 1000), np.random.rand(3, 2000)],
+            {"trace_sampling_rate_hz": [20, 25]},
+        )
+    }
+    filt(state_dict)
+
+    # Just sanity checks
+    assert len(state_dict["X"][0]) == 2
+    assert state_dict["X"][0][0].shape == (3, 1000)
+    assert state_dict["X"][0][1].shape == (3, 2000)
+
+
 def test_fixed_window():
     np.random.seed(42)
     base_state_dict = {

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1643,3 +1643,17 @@ def test_copy():
     # Check deepcopy ok
     state_dict["X"][0][0, 500] = 2
     assert state_dict["Xc"][0][0, 500] != 2
+
+
+def test_group_generator():
+    data = seisbench.data.DummyDataset()
+
+    with pytest.raises(ValueError):
+        seisbench.generate.GroupGenerator(data)
+
+    data.grouping = "source_magnitude"
+    generator = seisbench.generate.GroupGenerator(data)
+    assert len(generator) == len(data.groups)
+
+    # Check that sample can be retrieved
+    generator[0]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1781,7 +1781,25 @@ def test_utc_offsets():
 
 
 def test_select_or_pad_along_axis():
-    aug = seisbench.generate.SelectOrPadAlongAxis(n=5, axis=0, key=("X", "X2"))
+    aug = seisbench.generate.SelectOrPadAlongAxis(
+        n=5, repeat=True, axis=0, key=("X", "X2")
+    )
+
+    x = np.random.rand(2, 3, 1000)
+    state_dict = {"X": (x, {"something": [0.0, 5.0]})}
+
+    aug(state_dict)
+
+    x2, metadata2 = state_dict["X2"]
+    assert x2.shape == (5, 3, 1000)
+    assert np.allclose(x2[:2], x)
+    assert np.allclose(x2[2:4], x)
+    assert np.allclose(x2[4], x[0])
+    assert np.allclose(metadata2["something"], [0, 5, 0, 5, 0])
+
+    aug = seisbench.generate.SelectOrPadAlongAxis(
+        n=5, repeat=False, axis=0, key=("X", "X2")
+    )
 
     x = np.random.rand(2, 3, 1000)
     state_dict = {"X": (x, {"something": [0.0, 5.0]})}

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -125,6 +125,24 @@ def test_normalize():
         Normalize(amp_norm_type="Unknown normalization type")
 
 
+def test_normalize_unaligned_group():
+    # Negative axis definition
+    state_dict = {"X": ([np.random.rand(3, 1000), np.random.rand(3, 2000)], {})}
+
+    norm = Normalize(demean_axis=-1)
+    norm(state_dict)
+
+    assert np.allclose([np.mean(y) for y in state_dict["X"][0]], 0)
+
+    # Positive axis definition
+    state_dict = {"X": ([np.random.rand(3, 1000), np.random.rand(3, 2000)], {})}
+
+    norm = Normalize(demean_axis=1)
+    norm(state_dict)
+
+    assert np.allclose([np.mean(y) for y in state_dict["X"][0]], 0)
+
+
 def test_filter():
     np.random.seed(42)
     base_state_dict = {


### PR DESCRIPTION
This PR adds data grouping. This includes:

- grouping in WaveformDataset and MultiWaveformDataset
- a new GroupGenerator
- adjustment of several augmentations to deal with grouped data

Grouping allows to automatically retrieve sets of metadata and waveforms from a dataset. The waveforms are selected based on a common key. For example, this enables to group the data by event and then train multi-station models. However, as any grouping is possible, there are countless options for using the scheme.

This PR does not contain any models. It also does not contain any grouping for the `annotate`/`classify` function. Due to the scale of this feature addition, and to keep the PRs somewhat reasonably sized, I think it's still worthwhile including this part already.