### PR TITLE
Performance optimization for dataset access

### DIFF
--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -78,8 +78,8 @@ class WaveformDataset:
     :param metadata_cache: If true, metadata is cached in a lookup table.
                            This significantly speeds up access to metadata and thereby access to samples.
                            On the downside, this requires storing two copies of the metadata in memory.
-                           When short on memory, this option can be deactivated but at the cost of
-                           increased runtime. Runtime differences are particularly big for large datasets.
+                           The second copy usually consumes more memory due to the less space-efficient format.
+                           Runtime differences are particularly big for large datasets.
     :type bool:
     :param kwargs:
     """
@@ -94,7 +94,7 @@ class WaveformDataset:
         cache=None,
         chunks=None,
         missing_components="pad",
-        metadata_cache=True,
+        metadata_cache=False,
         **kwargs,
     ):
         if name is None:

--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -1098,7 +1098,7 @@ class WaveformDataset:
         :rtype: int
         """
         self._verify_grouping_defined()
-        group = self.groups[idx]
+        group = self._groups[idx]
         idx = self._groups_to_trace_idx[group]
         return len(idx)
 
@@ -1129,7 +1129,7 @@ class WaveformDataset:
     def _get_group_internal(self, idx, return_metadata, **kwargs):
         self._verify_grouping_defined()
 
-        group = self.groups[idx]
+        group = self._groups[idx]
         idx = self._groups_to_trace_idx[group]
 
         waveforms = []

--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -125,6 +125,7 @@ class WaveformDataset:
         # Dict [source_component_order -> list for reordering source to target components]
         self._component_mapping = None
         self._metadata_lookup = None
+        self._chunks_with_paths_cache = None
         self.sampling_rate = sampling_rate
 
         self._verify_dataset()
@@ -586,10 +587,21 @@ class WaveformDataset:
 
         :return: List of chunks, list of metadata paths, list of waveform paths
         """
-        metadata_paths = [self.path / f"metadata{chunk}.csv" for chunk in self.chunks]
-        waveform_paths = [self.path / f"waveforms{chunk}.hdf5" for chunk in self.chunks]
+        if self._chunks_with_paths_cache is None:
+            metadata_paths = [
+                self.path / f"metadata{chunk}.csv" for chunk in self.chunks
+            ]
+            waveform_paths = [
+                self.path / f"waveforms{chunk}.hdf5" for chunk in self.chunks
+            ]
 
-        return self.chunks, metadata_paths, waveform_paths
+            self._chunks_with_paths_cache = (
+                self.chunks,
+                metadata_paths,
+                waveform_paths,
+            )
+
+        return self._chunks_with_paths_cache
 
     def _verify_dataset(self):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1487,3 +1487,11 @@ def test_metadata_lookup():
 
         for key in meta_lookup.keys():
             assert meta_direct[key] == meta_lookup[key]
+
+
+def test_chunks_with_paths_cache():
+    data = seisbench.data.DummyDataset()
+
+    data._chunks_with_paths_cache = None
+    data._chunks_with_paths()
+    assert data._chunks_with_paths_cache is not None

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -494,7 +494,7 @@ def test_unify_component_order(caplog):
 
 
 def test_resample():
-    dummy = seisbench.data.DummyDataset()
+    dummy = seisbench.data.DummyDataset(metadata_cache=False)
     dummy._metadata["trace_sampling_rate_hz"] = 20.0
     dummy._metadata["trace_sampling_rate_hz"].values[0] = np.nan
 
@@ -543,15 +543,20 @@ def test_resample_empty_trace(caplog):
     assert "Trying to resample empty trace, skipping resampling." in caplog.text
 
 
-def test_get_sample():
+@pytest.mark.parametrize(
+    "metadata_cache",
+    [True, False],
+)
+def test_get_sample(metadata_cache):
     # Checks that the parameters are correctly overwritten, when the sampling_rate is changed
-    dummy = seisbench.data.DummyDataset()
+    dummy = seisbench.data.DummyDataset(metadata_cache=metadata_cache)
     dummy.sampling_rate = None
 
     base_sampling_rate = dummy.metadata.iloc[0]["trace_sampling_rate_hz"]
     base_arrival_sample = 500
     dummy._metadata["trace_p_arrival_sample"] = base_arrival_sample
     dummy._metadata["trace_dt_s"] = 1 / dummy._metadata["trace_sampling_rate_hz"]
+    dummy._rebuild_metadata_cache()
 
     # No resampling
     waveforms, metadata = dummy.get_sample(0, sampling_rate=None)
@@ -860,6 +865,7 @@ def test_get_waveforms_component_orders():
     assert (wv_org == wv).all()
 
     dummy._metadata["trace_component_order"].values[1] = "NEZ"
+    dummy._rebuild_metadata_cache()
     dummy.component_order = "ZNE"
     dummy.missing_components = "ignore"
 
@@ -876,6 +882,7 @@ def test_get_waveform_component_order_mismatching():
     # Tests different strategies for mismatching traces
     dummy = seisbench.data.DummyDataset(component_order="ZNE", dimension_order="NCW")
     dummy._metadata["trace_component_order"].values[1] = "Z"
+    dummy._rebuild_metadata_cache()
 
     dummy.missing_components = "pad"
     wv = dummy.get_waveforms([0, 1])
@@ -1459,3 +1466,24 @@ def test_grouping_index_filter():
     # Check that actually the index was reset and the group keys are indices now
     for i in range(len(data)):
         assert any(i in group_keys for group_keys in data._groups_to_trace_idx.values())
+
+
+def test_metadata_lookup():
+    data = seisbench.data.DummyDataset(metadata_cache=False)
+    assert data._metadata_lookup is None
+
+    data = seisbench.data.DummyDataset(metadata_cache=True)
+    assert len(data._metadata_lookup) == len(data.metadata)
+
+    mask = np.zeros(len(data), dtype=bool)
+    mask[:20] = True
+
+    data.filter(mask, inplace=True)
+    assert len(data._metadata_lookup) == len(data.metadata)
+
+    for i in range(len(data)):
+        meta_lookup = data._metadata_lookup[i]
+        meta_direct = data.metadata.iloc[i].to_dict()
+
+        for key in meta_lookup.keys():
+            assert meta_direct[key] == meta_lookup[key]


### PR DESCRIPTION
This PR implements several performance optimization for accessing datasets. They improve throughput and thereby training speed considerably. The specific improvements are:

- cache output of `_chunks_with_path_cache`. The return value is static and the function is called for every call to `get_waveforms`. Reduces runtime of `get_waveforms` by ~20 %.
- Add option to activate a metadata lookup table. Reduces runtime for `get_sample` by more than 50 %. As this comes at the cost of a longer compute at initialisation and significantly higher memory overhead, this optimization is deactivated by default.
- *(only for grouped datasets)* remove unnecessary copy operations in the list of groups (for large datasets speedup can exceed 10x)

*Remark:* Due to a lack of potential reviewers, I'll merge the PR once the tests pass. This PR serves mostly documentation purposes.