### PR TITLE
Homogenized annotate arguments

### DIFF
--- a/seisbench/models/aepicker.py
+++ b/seisbench/models/aepicker.py
@@ -28,6 +28,7 @@ class BasicPhaseAE(WaveformModel):
 
     _annotate_args = WaveformModel._annotate_args.copy()
     _annotate_args["*_threshold"] = ("Detection threshold for the provided phase", 0.3)
+    _annotate_args["overlap"] = (_annotate_args["overlap"][0], 300)
 
     def __init__(
         self, in_channels=3, classes=3, phases="NPS", sampling_rate=100, **kwargs
@@ -44,7 +45,6 @@ class BasicPhaseAE(WaveformModel):
             citation=citation,
             in_samples=600,
             output_type="array",
-            default_args={"overlap": 300},
             pred_sample=(0, 600),
             labels=phases,
             sampling_rate=sampling_rate,

--- a/seisbench/models/cred.py
+++ b/seisbench/models/cred.py
@@ -17,6 +17,7 @@ class CRED(WaveformModel):
 
     _annotate_args = WaveformModel._annotate_args.copy()
     _annotate_args["detection_threshold"] = ("Detection threshold", 0.5)
+    _annotate_args["overlap"] = (_annotate_args["overlap"][0], 1500)
 
     def __init__(
         self,
@@ -39,7 +40,6 @@ class CRED(WaveformModel):
             in_samples=in_samples,
             output_type="array",
             pred_sample=(0, in_samples),
-            default_args={"overlap": 1500},
             **kwargs,
         )
 

--- a/seisbench/models/deepdenoiser.py
+++ b/seisbench/models/deepdenoiser.py
@@ -9,6 +9,9 @@ from .base import WaveformModel
 
 
 class DeepDenoiser(WaveformModel):
+    _annotate_args = WaveformModel._annotate_args.copy()
+    _annotate_args["overlap"] = (_annotate_args["overlap"][0], 1500)
+
     def __init__(self, sampling_rate=100, **kwargs):
         citation = (
             "Zhu, W., Mousavi, S. M., & Beroza, G. C. (2019). "
@@ -21,7 +24,6 @@ class DeepDenoiser(WaveformModel):
             citation=citation,
             in_samples=3000,
             output_type="array",
-            default_args={"overlap": 1000},
             pred_sample=(0, 3000),
             labels=self.generate_label,
             sampling_rate=sampling_rate,

--- a/seisbench/models/eqtransformer.py
+++ b/seisbench/models/eqtransformer.py
@@ -43,7 +43,7 @@ class EQTransformer(WaveformModel):
     _annotate_args["detection_threshold"] = ("Detection threshold", 0.3)
     _annotate_args["blinding"] = (
         "Number of prediction samples to discard on each side of each window prediction",
-        (0, 0),
+        (500, 500),
     )
     # Overwrite default stacking method
     _annotate_args["stacking"] = (
@@ -51,6 +51,7 @@ class EQTransformer(WaveformModel):
         "Options are 'max' and 'avg'. ",
         "max",
     )
+    _annotate_args["overlap"] = (_annotate_args["overlap"][0], 3000)
 
     def __init__(
         self,
@@ -76,7 +77,6 @@ class EQTransformer(WaveformModel):
         super().__init__(
             citation=citation,
             output_type="array",
-            default_args={"overlap": 3000, "blinding": (500, 500)},
             in_samples=in_samples,
             pred_sample=(0, in_samples),
             labels=["Detection"] + list(phases),

--- a/seisbench/models/gpd.py
+++ b/seisbench/models/gpd.py
@@ -12,6 +12,7 @@ class GPD(WaveformModel):
 
     _annotate_args = WaveformModel._annotate_args.copy()
     _annotate_args["*_threshold"] = ("Detection threshold for the provided phase", 0.7)
+    _annotate_args["stride"] = (_annotate_args["stride"][0], 10)
 
     def __init__(
         self,
@@ -36,7 +37,6 @@ class GPD(WaveformModel):
             pred_sample=pred_sample,
             labels=phases,
             sampling_rate=sampling_rate,
-            default_args={"stride": 10},
             **kwargs,
         )
 

--- a/seisbench/models/phasenet.py
+++ b/seisbench/models/phasenet.py
@@ -17,6 +17,7 @@ class PhaseNet(WaveformModel):
         "Number of prediction samples to discard on each side of each window prediction",
         (0, 0),
     )
+    _annotate_args["overlap"] = (_annotate_args["overlap"][0], 1500)
 
     def __init__(
         self, in_channels=3, classes=3, phases="NPS", sampling_rate=100, **kwargs
@@ -32,7 +33,6 @@ class PhaseNet(WaveformModel):
             citation=citation,
             in_samples=3001,
             output_type="array",
-            default_args={"overlap": 1500},
             pred_sample=(0, 3001),
             labels=phases,
             sampling_rate=sampling_rate,
@@ -231,7 +231,6 @@ class PhaseNetLight(PhaseNet):
             citation=citation,
             in_samples=3001,
             output_type="array",
-            default_args={"overlap": 1500},
             pred_sample=(0, 3001),
             labels=phases,
             sampling_rate=sampling_rate,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -253,7 +253,7 @@ def test_stream_to_arrays_instrument():
 
     # Aligned strict
     stream = obspy.Stream([trace_z, trace_n, trace_e])
-    times, data = dummy.stream_to_arrays(stream, strict=True)
+    times, data = dummy.stream_to_arrays(stream, {"strict": True})
     assert len(times) == len(data) == 1
     assert times[0] == t0
     assert data[0].shape == (3, len(trace_z.data))
@@ -263,7 +263,7 @@ def test_stream_to_arrays_instrument():
 
     # Aligned non strict
     stream = obspy.Stream([trace_z, trace_n, trace_e])
-    times, data = dummy.stream_to_arrays(stream, strict=False)
+    times, data = dummy.stream_to_arrays(stream, {"strict": False})
     assert len(times) == len(data) == 1
     assert times[0] == t0
     assert data[0].shape == (3, len(trace_z.data))
@@ -273,7 +273,7 @@ def test_stream_to_arrays_instrument():
 
     # Covering strict
     stream = obspy.Stream([trace_z, trace_n, trace_e.slice(t0 + 1, t0 + 5)])
-    times, data = dummy.stream_to_arrays(stream, strict=True)
+    times, data = dummy.stream_to_arrays(stream, {"strict": True})
     assert len(times) == len(data) == 1
     assert times[0] == t0 + 1
     assert data[0].shape == (3, 401)
@@ -283,7 +283,7 @@ def test_stream_to_arrays_instrument():
 
     # Covering non-strict
     stream = obspy.Stream([trace_z, trace_n, trace_e.slice(t0 + 1, t0 + 5)])
-    times, data = dummy.stream_to_arrays(stream, strict=False)
+    times, data = dummy.stream_to_arrays(stream, {"strict": False})
     assert len(times) == len(data) == 1
     assert times[0] == t0
     assert data[0].shape == (3, len(trace_z.data))
@@ -297,7 +297,7 @@ def test_stream_to_arrays_instrument():
     stream = obspy.Stream(
         [trace_z, trace_n, trace_e.slice(t0 + 1, t0 + 5), trace_e.slice(t0 + 6, t0 + 8)]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=True)
+    times, data = dummy.stream_to_arrays(stream, {"strict": True})
     assert len(times) == len(data) == 2
     assert times[0] == t0 + 1
     assert times[1] == t0 + 6
@@ -312,7 +312,7 @@ def test_stream_to_arrays_instrument():
     stream = obspy.Stream(
         [trace_z, trace_n, trace_e.slice(t0 + 1, t0 + 5), trace_e.slice(t0 + 6, t0 + 8)]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=False)
+    times, data = dummy.stream_to_arrays(stream, {"strict": False})
     assert len(times) == len(data) == 1
     assert times[0] == t0
     assert data[0].shape == (3, len(trace_z.data))
@@ -328,7 +328,7 @@ def test_stream_to_arrays_instrument():
     stream = obspy.Stream(
         [trace_z, trace_n.slice(t0 + 1, t0 + 5), trace_e.slice(t0 + 3, t0 + 7)]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=True)
+    times, data = dummy.stream_to_arrays(stream, {"strict": True})
     assert len(times) == len(data) == 1
     assert times[0] == t0 + 3
     assert data[0].shape == (3, 201)
@@ -340,7 +340,7 @@ def test_stream_to_arrays_instrument():
     stream = obspy.Stream(
         [trace_z, trace_n.slice(t0 + 1, t0 + 5), trace_e.slice(t0 + 3, t0 + 7)]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=False)
+    times, data = dummy.stream_to_arrays(stream, {"strict": False})
     assert len(times) == len(data) == 1
     assert times[0] == t0
     assert data[0].shape == (3, len(trace_z.data))
@@ -360,7 +360,7 @@ def test_stream_to_arrays_instrument():
             trace_e.slice(t0 + 1, t0 + 2),
         ]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=True)
+    times, data = dummy.stream_to_arrays(stream, {"strict": True})
     assert len(times) == len(data) == 0
 
     # No overlap non strict
@@ -371,7 +371,7 @@ def test_stream_to_arrays_instrument():
             trace_e.slice(t0 + 1, t0 + 2),
         ]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=False)
+    times, data = dummy.stream_to_arrays(stream, {"strict": False})
     assert len(times) == len(data) == 1
     assert times[0] == t0
     assert data[0].shape == (3, 201)
@@ -393,7 +393,7 @@ def test_stream_to_arrays_instrument():
             trace_e.slice(t0 + 2, t0 + 3),
         ]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=True)
+    times, data = dummy.stream_to_arrays(stream, {"strict": True})
     assert len(times) == len(data) == 2
     for i in range(2):
         assert times[i] == t0 + 2 * i
@@ -413,7 +413,7 @@ def test_stream_to_arrays_instrument():
             trace_e.slice(t0 + 2, t0 + 3),
         ]
     )
-    times, data = dummy.stream_to_arrays(stream, strict=False)
+    times, data = dummy.stream_to_arrays(stream, {"strict": False})
     assert len(times) == len(data) == 2
     for i in range(2):
         assert times[i] == t0 + 2 * i
@@ -438,9 +438,7 @@ def test_stream_to_arrays_channel():
 
     # Simple
     stream = obspy.Stream([trace_z])
-    times, data = dummy.stream_to_arrays(
-        stream,
-    )
+    times, data = dummy.stream_to_arrays(stream, {})
     assert len(times) == len(data) == 1
     assert times[0] == t0
     assert data[0].shape == (len(trace_z.data),)
@@ -448,7 +446,7 @@ def test_stream_to_arrays_channel():
 
     # Separate fragments
     stream = obspy.Stream([trace_z.slice(t0, t0 + 1), trace_z.slice(t0 + 2, t0 + 3)])
-    times, data = dummy.stream_to_arrays(stream, strict=True)
+    times, data = dummy.stream_to_arrays(stream, {"strict": True})
     assert len(times) == len(data) == 2
     for i in range(2):
         assert times[i] == t0 + 2 * i
@@ -511,14 +509,14 @@ def test_flexible_horizontal_components(caplog):
     # flexible_horizontal_components=False
     stream = obspy.Stream([trace_z, trace_1, trace_2])
     times, data = dummy.stream_to_arrays(
-        stream, strict=True, flexible_horizontal_components=False
+        stream, {"strict": True, "flexible_horizontal_components": False}
     )
     assert len(times) == len(data) == 0
 
     # flexible_horizontal_components=True
     stream = obspy.Stream([trace_z, trace_1, trace_2])
     times, data = dummy.stream_to_arrays(
-        stream, strict=True, flexible_horizontal_components=True
+        stream, {"strict": True, "flexible_horizontal_components": True}
     )
     assert len(times) == len(data) == 1
 
@@ -527,7 +525,7 @@ def test_flexible_horizontal_components(caplog):
     stream = obspy.Stream([trace_z, trace_n, trace_e, trace_1, trace_2])
     with caplog.at_level(logging.WARNING):
         times, data = dummy.stream_to_arrays(
-            stream, strict=True, flexible_horizontal_components=True
+            stream, {"strict": True, "flexible_horizontal_components": True}
         )
     assert "This might lead to undefined behavior." in caplog.text
     assert len(times) == len(data) == 1
@@ -536,7 +534,9 @@ def test_flexible_horizontal_components(caplog):
     caplog.clear()
     stream = obspy.Stream([trace_z, trace_n, trace_e, trace_2_test2])
     with caplog.at_level(logging.WARNING):
-        dummy.stream_to_arrays(stream, strict=True, flexible_horizontal_components=True)
+        dummy.stream_to_arrays(
+            stream, {"strict": True, "flexible_horizontal_components": True}
+        )
     assert "This might lead to undefined behavior." not in caplog.text
 
 
@@ -1195,10 +1195,6 @@ def test_eqtransformer_annotate_window_post():
     model = seisbench.models.EQTransformer()
 
     pred = 3 * [np.ones(1000)]
-
-    # Default: No blinding
-    blinded = model.annotate_window_post(pred, argdict={})
-    assert (blinded == 1).all()
 
     # No blinding
     blinded = model.annotate_window_post(pred, argdict={"blinding": (0, 0)})
@@ -2083,3 +2079,11 @@ def test_cred_forward():
         pred_logit = model(x, logits=True).numpy()
 
     assert not np.allclose(pred, pred_logit)
+
+
+def test_argdict_get_with_default():
+    model = seisbench.models.PhaseNet()
+    model._annotate_args["testarg"] = ("Test docstr", 1)
+
+    assert model._argdict_get_with_default({"testarg": 2}, "testarg") == 2
+    assert model._argdict_get_with_default({"not_testarg": 2}, "testarg") == 1


### PR DESCRIPTION
- Make `strict` and `flexible_horizontal_components` annotate arguments instead of listing them separately in the function head.
- Remove `default_args` set in the constructor by overwrites to `_annotate_args`. This ensures that the documentation lists the correct default values.
- Factor out function to query arguments with defaults from the `_annotate_args`.