### PR TITLE
bug_fix: adding model.eval() and model.train() in example notebooks

### DIFF
--- a/examples/03a_training_phasenet.ipynb
+++ b/examples/03a_training_phasenet.ipynb
@@ -450,10 +450,14 @@
     "    num_batches = len(dataloader)\n",
     "    test_loss = 0\n",
     "\n",
+    "    model.eval()  # close the model for evaluation\n",
+    "\n",
     "    with torch.no_grad():\n",
     "        for batch in dataloader:\n",
     "            pred = model(batch[\"X\"].to(model.device))\n",
     "            test_loss += loss_fn(pred, batch[\"y\"].to(model.device)).item()\n",
+    "\n",
+    "    model.train()  # re-open model for training stage\n",
     "\n",
     "    test_loss /= num_batches\n",
     "    print(f\"Test avg loss: {test_loss:>8f} \\n\")"
@@ -648,6 +652,8 @@
     "axs[0].plot(sample[\"X\"].T)\n",
     "axs[1].plot(sample[\"y\"].T)\n",
     "\n",
+    "model.eval()  # close the model for evaluation\n",
+    "\n",
     "with torch.no_grad():\n",
     "    pred = model(torch.tensor(sample[\"X\"], device=model.device).unsqueeze(0))  # Add a fake batch dimension\n",
     "    pred = pred[0].cpu().numpy()\n",
@@ -764,7 +770,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the [`03a_training_phasenet.ipynb`](https://github.com/seisbench/seisbench/blob/main/examples/03a_training_phasenet.ipynb) notebook the `model.eval()` call was missing (code-block 11). This call is needed to close the re-trained model, and is done automatically by the `annotate` method. In the notebook, though, must be specified. I've added such a switch in the `test_loop` function as well.
