### PR TITLE
post-processing: removing bottleneck nanmean/max

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ name = "seisbench"
 dynamic = ["version"]
 description = "The seismological machine learning benchmark collection"
 readme = "README.md"
-license = {text = "GPLv3"}
+license = { text = "GPLv3" }
 requires-python = ">=3.7"
 authors = [
-    {name = "Jack Woolam", email = "jack.woollam@kit.edu"},
-    {name = "Jannes Münchmeyer", email = "munchmej@gfz-potsdam.de"}
+    { name = "Jack Woolam", email = "jack.woollam@kit.edu" },
+    { name = "Jannes Münchmeyer", email = "munchmej@gfz-potsdam.de" },
 ]
 maintainers = [
-    {name = "Jack Woolam", email = "jack.woollam@kit.edu"},
-    {name = "Jannes Münchmeyer", email = "munchmej@gfz-potsdam.de"}
+    { name = "Jack Woolam", email = "jack.woollam@kit.edu" },
+    { name = "Jannes Münchmeyer", email = "munchmej@gfz-potsdam.de" },
 ]
 keywords = ["seismology", "machine learning", "signal processing", "earthquake"]
 classifiers = [
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3.7",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
     "numpy>=1.21.6",
@@ -33,7 +33,8 @@ dependencies = [
     "tqdm>=4.52",
     "torch>=1.10.0",
     "scipy>=1.5",
-    "nest_asyncio>=1.5.3"
+    "nest_asyncio>=1.5.3",
+    "bottleneck>=1.3",
 ]
 
 [tool.setuptools.packages.find]

--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from queue import PriorityQueue
 from urllib.parse import urljoin
 
+import bottleneck as bn
 import nest_asyncio
 import numpy as np
 import obspy
@@ -1724,10 +1725,10 @@ class WaveformModel(SeisBenchModel, ABC):
                     warnings.filterwarnings(
                         action="ignore", message="Mean of empty slice"
                     )
-                    preds = np.nanmean(pred_merge, axis=-1)
+                    preds = bn.nanmean(pred_merge, axis=-1)
                 elif stack_method == "max":
                     warnings.filterwarnings(action="ignore", message="All-NaN")
-                    preds = np.nanmax(pred_merge, axis=-1)
+                    preds = bn.nanmax(pred_merge, axis=-1)
                 # Case of stack_method not in avg or max is caught by assert above
 
             pred_time = t0 + self.pred_sample[0] / argdict["sampling_rate"]
@@ -1829,6 +1830,9 @@ class WaveformModel(SeisBenchModel, ABC):
         finally:
             if train_mode:
                 self.train()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
         preds = self._recursive_torch_to_numpy(preds)
         # Unbatch window predictions
         reshaped_preds = [pred for pred in self._recursive_slice_pred(preds)]


### PR DESCRIPTION
A bottleneck is the usage of `nanmean` and `nanmax`.

This dirty quick fix is replacing those functions with fuctions from the library bottleneck (https://github.com/pydata/bottleneck).

For my usecase I sped up the inference by ~30%.