### PR TITLE
Change grouping behaviour for grouping="instrument" (Closes #196)

### DIFF
--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -2180,13 +2180,17 @@ class WaveformModel(SeisBenchModel, ABC):
         groups = defaultdict(list)
         for trace in stream:
             if self._grouping == "instrument":
-                groups[trace.id[:-1]].append(trace)
+                groups[self._trace_id_without_component(trace)].append(trace)
             elif self._grouping == "channel":
                 groups[trace.id].append(trace)
             else:
                 raise ValueError(f"Unknown grouping parameter '{by}'.")
 
         return list(groups.values())
+
+    @staticmethod
+    def _trace_id_without_component(trace: obspy.Trace):
+        return f"{trace.stats.network}.{trace.stats.station}.{trace.stats.location}"
 
     @staticmethod
     def sanitize_mismatching_overlapping_records(stream):
@@ -2317,7 +2321,9 @@ class WaveformModel(SeisBenchModel, ABC):
             if trace.id[-1] in comp_dict and len(trace.data) > 0:
                 start_sorted.put((trace.stats.starttime, seqnum, trace))
                 seqnum += 1
-                existing_trace_components[trace.id[:-1]].append(trace.id[-1])
+                existing_trace_components[
+                    self._trace_id_without_component(trace)
+                ].append(trace.id[-1])
 
         if flexible_horizontal_components:
             for trace, components in existing_trace_components.items():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -541,7 +541,7 @@ def test_flexible_horizontal_components(caplog):
 
 
 def test_group_stream_by_instrument():
-    # The first 3 should be grouped together, the last 3 should each be separate
+    # The first 4 should be grouped together, the last 2 should each be separate
     stream = obspy.Stream(
         [
             obspy.Trace(header={"network": "SB", "station": "ABC1", "channel": "BHZ"}),
@@ -558,8 +558,8 @@ def test_group_stream_by_instrument():
     dummy._grouping = "instrument"
     groups = dummy.group_stream(stream)
 
-    assert len(groups) == 4
-    assert list(sorted([len(x) for x in groups])) == [1, 1, 1, 3]
+    assert len(groups) == 3
+    assert list(sorted([len(x) for x in groups])) == [1, 1, 4]
 
     dummy._grouping = "channel"
     groups = dummy.group_stream(stream)


### PR DESCRIPTION
Instead of separating instruments with different channel codes into different groups, they are now put into the same group, e.g., BH? and HH? are now in the same group. The grouping key is NET.STA.LOC. This change is necessary for many OBS deployment, where the channel codes aren't identical between the hydrophone and the seismic sensor.