### PR TITLE
Adding options for disabling normalization and noise label for ProbabilisticLabeller, and checking picks for AddGap and ChannelDropout.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,9 @@ repos:
     args: ['--maxkb=1000']
   - id: check-toml
   - id: check-json
-  - id: pretty-format-json
-    args: [--autofix]
+# Hook shows incompatibility with ipynb files
+#  - id: pretty-format-json
+#    args: [--autofix]
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/pycqa/isort

--- a/seisbench/generate/augmentation.py
+++ b/seisbench/generate/augmentation.py
@@ -416,15 +416,15 @@ class AddGap:
                 Otherwise, a 2-tuple is expected, with the first string indicating the key to
                 read from and the second one the key to write to.
     :type key: str, tuple[str, str]
-    :param picks_in_gap_thre: If a pick is within the gap and the distance from the pick to the
-                              gap border is larger than `picks_in_gap_thre` (unit: sample), this
-                              pick will be ignored and the corresponding arrival sample in the
-                              metadata will be set to NaN. If `picks_in_gap_thre` is None, skip
-                              the check.
-    :type picks_in_gap_thre: int, None
+    :param picks_in_gap_threshold: If a pick is within the gap and the distance from the pick to the
+                                   gap border is larger than `picks_in_gap_thre` (unit: sample), this
+                                   pick will be ignored and the corresponding arrival sample in the
+                                   metadata will be set to NaN. If `picks_in_gap_thre` is None, skip
+                                   the check.
+    :type picks_in_gap_threshold: int, None
     """
 
-    def __init__(self, axis=-1, key="X", picks_in_gap_thre=None):
+    def __init__(self, axis=-1, key="X", picks_in_gap_threshold=None):
         if isinstance(key, str):
             self.key = (key, key)
         else:
@@ -432,10 +432,7 @@ class AddGap:
 
         self.axis = axis
 
-        if isinstance(picks_in_gap_thre, int):
-            self.picks_in_gap_thre = picks_in_gap_thre
-        else:
-            self.picks_in_gap_thre = None
+        self.picks_in_gap_threshold = picks_in_gap_threshold
 
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key[0]]
@@ -462,14 +459,14 @@ class AddGap:
                 gap = np.expand_dims(gap, -1)
 
         np.put_along_axis(x, gap, 0, axis=axis)
-        if self.picks_in_gap_thre is not None:
+        if self.picks_in_gap_threshold is not None:
             for key in metadata.keys():
                 if key.endswith("_arrival_sample"):
                     if isinstance(metadata[key], (int, np.integer, float)):
                         # Handle single window case
                         if (
                             min(metadata[key] - gap_start, gap_end - 1 - metadata[key])
-                            >= self.picks_in_gap_thre
+                            >= self.picks_in_gap_threshold
                         ):
                             metadata[key] = np.nan
                     else:
@@ -480,7 +477,7 @@ class AddGap:
                                     metadata[key][j] - gap_start,
                                     gap_end - 1 - metadata[key][j],
                                 )
-                                >= self.picks_in_gap_thre
+                                >= self.picks_in_gap_threshold
                             ):
                                 try:
                                     metadata[key][j] = np.nan

--- a/seisbench/generate/augmentation.py
+++ b/seisbench/generate/augmentation.py
@@ -349,15 +349,19 @@ class ChannelDropout:
                 Otherwise, a 2-tuple is expected, with the first string indicating the key to
                 read from and the second one the key to write to.
     :type key: str, tuple[str, str]
+    :param check_picks_in_gap: If true, check whether all channels are zero after channel
+                               dropping and if so, set phase arrivals to NaN.
+    :type check_picks_in_gap: bool
     """
 
-    def __init__(self, axis=-2, key="X"):
+    def __init__(self, axis=-2, key="X", check_picks_in_gap=False):
         if isinstance(key, str):
             self.key = (key, key)
         else:
             self.key = key
 
         self.axis = axis
+        self.check_picks_in_gap = check_picks_in_gap
 
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key[0]]
@@ -386,11 +390,12 @@ class ChannelDropout:
                     drop_channels = np.expand_dims(drop_channels, -1)
 
             np.put_along_axis(x, drop_channels, 0, axis=axis)
-            if np.isclose(np.sum(x), 0):
-                # if all channels are zeros, ignore original phase arrivals
-                for key in metadata.keys():
-                    if key.endswith("_arrival_sample"):
-                        metadata[key] = np.nan
+            if self.check_picks_in_gap:
+                if np.allclose(x, 0):
+                    # if all channels are zeros, ignore original phase arrivals
+                    for key in metadata.keys():
+                        if key.endswith("_arrival_sample"):
+                            metadata[key] = np.nan
 
         state_dict[self.key[1]] = (x, metadata)
 
@@ -406,18 +411,26 @@ class AddGap:
                 Otherwise, a 2-tuple is expected, with the first string indicating the key to
                 read from and the second one the key to write to.
     :type key: str, tuple[str, str]
-    :param check_arrivals_in_gap: If true, set the phase arrivals in the gap to NaN.
-    :type check_arrivals_in_gap: bool
+    :param picks_in_gap_thre: If a pick is within the gap and the distance from the pick to the
+                              gap border is larger than `picks_in_gap_thre` (unit: sample), this
+                              pick will be ignored and the corresponding arrival sample in the
+                              metadata will be set to NaN. If `picks_in_gap_thre` is None, skip
+                              the check.
+    :type picks_in_gap_thre: int, None
     """
 
-    def __init__(self, axis=-1, key="X", check_arrivals_in_gap=False):
+    def __init__(self, axis=-1, key="X", picks_in_gap_thre=None):
         if isinstance(key, str):
             self.key = (key, key)
         else:
             self.key = key
 
         self.axis = axis
-        self.check_arrivals_in_gap = check_arrivals_in_gap
+
+        if isinstance(picks_in_gap_thre, int):
+            self.picks_in_gap_thre = picks_in_gap_thre
+        else:
+            self.picks_in_gap_thre = None
 
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key[0]]
@@ -444,10 +457,13 @@ class AddGap:
                 gap = np.expand_dims(gap, -1)
 
         np.put_along_axis(x, gap, 0, axis=axis)
-        if self.check_arrivals_in_gap:
+        if self.picks_in_gap_thre is not None:
             for key in metadata.keys():
                 if key.endswith("_arrival_sample"):
-                    if gap_start <= metadata[key] and metadata[key] < gap_end:
+                    if (
+                        min(metadata[key] - gap_start, gap_end - 1 - metadata[key])
+                        >= self.picks_in_gap_thre
+                    ):
                         metadata[key] = np.nan
         state_dict[self.key[1]] = (x, metadata)
 

--- a/seisbench/generate/augmentation.py
+++ b/seisbench/generate/augmentation.py
@@ -386,6 +386,11 @@ class ChannelDropout:
                     drop_channels = np.expand_dims(drop_channels, -1)
 
             np.put_along_axis(x, drop_channels, 0, axis=axis)
+            if np.isclose(np.sum(x), 0):
+                # if all channels are zeros, ignore original phase arrivals
+                for key in metadata.keys():
+                    if key.endswith("_arrival_sample"):
+                        metadata[key] = np.nan
 
         state_dict[self.key[1]] = (x, metadata)
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -657,113 +657,112 @@ def test_change_dtype():
     )  # Metadata was copied and not only a pointer was copies
 
 
-def test_probabilistic_pick_labeller():
-    for noise_column in [True, False]:
-        for shape in ["gaussian", "triangle", "box"]:
-            np.random.seed(42)
-            state_dict = {
-                "X": (
-                    10 * np.random.rand(3, 1000),
-                    {
-                        "trace_p_arrival_sample": 500,
-                        "trace_s_arrival_sample": 700,
-                        "trace_g_arrival_sample": np.nan,
-                    },
-                )
-            }
+@pytest.mark.parametrize(
+    "noise_column,shape",
+    [
+        (True, "gaussian"),
+        (True, "triangle"),
+        (True, "box"),
+        (False, "gaussian"),
+        (False, "triangle"),
+        (False, "box"),
+    ],
+)
+def test_probabilistic_pick_labeller(noise_column, shape):
+    np.random.seed(42)
+    state_dict = {
+        "X": (
+            10 * np.random.rand(3, 1000),
+            {
+                "trace_p_arrival_sample": 500,
+                "trace_s_arrival_sample": 700,
+                "trace_g_arrival_sample": np.nan,
+            },
+        )
+    }
 
-            # Assumes standard config['dimension_order'] = 'NCW'
-            # Test label construction for single window, handling NaN values
-            labeller = ProbabilisticLabeller(
-                dim=0, shape=shape, noise_column=noise_column
-            )
-            labeller(state_dict)
+    # Assumes standard config['dimension_order'] = 'NCW'
+    # Test label construction for single window, handling NaN values
+    labeller = ProbabilisticLabeller(dim=0, shape=shape, noise_column=noise_column)
+    labeller(state_dict)
 
-            if noise_column:
-                assert state_dict["y"][0].shape == (4, 1000)
-                assert np.allclose(
-                    np.sum(state_dict["y"][0], axis=0), 1
-                )  # Sum is always 1
-            else:
-                assert state_dict["y"][0].shape == (3, 1000)
-                assert ~np.allclose(
-                    np.sum(state_dict["y"][0], axis=0), 1
-                )  # Sum may not be 1
-            assert np.isclose(
-                np.min(state_dict["y"][0]), 0
-            )  # Minimum is close to 0, in particular noise is never negative
+    if noise_column:
+        assert state_dict["y"][0].shape == (4, 1000)
+        assert np.allclose(np.sum(state_dict["y"][0], axis=0), 1)  # Sum is always 1
+    else:
+        assert state_dict["y"][0].shape == (3, 1000)
+        assert ~np.allclose(np.sum(state_dict["y"][0], axis=0), 1)  # Sum may not be 1
+    assert np.isclose(
+        np.min(state_dict["y"][0]), 0
+    )  # Minimum is close to 0, in particular noise is never negative
 
-            if shape == "box":
-                assert np.array_equiv(state_dict["y"][0][1][490:510], np.ones(20))
-                assert np.array_equiv(state_dict["y"][0][2][690:710], np.ones(20))
-            else:
-                assert np.argmax(state_dict["y"][0], axis=1)[1] == 500
-                assert np.argmax(state_dict["y"][0], axis=1)[2] == 700
-            assert (
-                state_dict["y"][0][0] == 0
-            ).all()  # Check that NaN picks are interpreted as not present
+    if shape == "box":
+        assert np.array_equiv(state_dict["y"][0][1][490:510], np.ones(20))
+        assert np.array_equiv(state_dict["y"][0][2][690:710], np.ones(20))
+    else:
+        assert np.argmax(state_dict["y"][0], axis=1)[1] == 500
+        assert np.argmax(state_dict["y"][0], axis=1)[2] == 700
+    assert (
+        state_dict["y"][0][0] == 0
+    ).all()  # Check that NaN picks are interpreted as not present
 
-            # Fails when multi_class specified and channel dim sum > 1
-            with pytest.raises(ValueError):
-                labeller = ProbabilisticLabeller(dim=1, shape=shape)
-                labeller(state_dict)
+    # Fails when multi_class specified and channel dim sum > 1
+    with pytest.raises(ValueError):
+        labeller = ProbabilisticLabeller(dim=1, shape=shape)
+        labeller(state_dict)
 
-            # Test label construction for multiple windows
-            state_dict = {
-                "X": (
-                    10 * np.random.rand(5, 3, 1000),
-                    {
-                        "trace_p_arrival_sample": np.array([500] * 5),
-                        "trace_s_arrival_sample": np.array([700] * 5),
-                        "trace_g_arrival_sample": np.array(
-                            [500, 500, 200, np.nan, 500]
-                        ),
-                    },
-                )
-            }
-            labeller = ProbabilisticLabeller(
-                dim=1, shape=shape, noise_column=noise_column
-            )
-            labeller(state_dict)
+    # Test label construction for multiple windows
+    state_dict = {
+        "X": (
+            10 * np.random.rand(5, 3, 1000),
+            {
+                "trace_p_arrival_sample": np.array([500] * 5),
+                "trace_s_arrival_sample": np.array([700] * 5),
+                "trace_g_arrival_sample": np.array([500, 500, 200, np.nan, 500]),
+            },
+        )
+    }
+    labeller = ProbabilisticLabeller(dim=1, shape=shape, noise_column=noise_column)
+    labeller(state_dict)
 
-            if noise_column:
-                assert state_dict["y"][0].shape == (5, 4, 1000)
-            else:
-                assert state_dict["y"][0].shape == (5, 3, 1000)
-            if shape == "box":
-                assert np.array_equiv(state_dict["y"][0][3, 1, 490:510], np.ones(20))
-                assert np.array_equiv(state_dict["y"][0][3, 2, 690:710], np.ones(20))
-                assert np.array_equiv(
-                    state_dict["y"][0][2, 0, 190:210], np.ones(20)
-                )  # Entry with pick
-            else:
-                assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[1] == 500
-                assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[2] == 700
-                assert (
-                    np.argmax(state_dict["y"][0][2, :, :], axis=-1)[0] == 200
-                )  # Entry with pick
-            assert (state_dict["y"][0][3, 0, :] == 0).all()
+    if noise_column:
+        assert state_dict["y"][0].shape == (5, 4, 1000)
+    else:
+        assert state_dict["y"][0].shape == (5, 3, 1000)
+    if shape == "box":
+        assert np.array_equiv(state_dict["y"][0][3, 1, 490:510], np.ones(20))
+        assert np.array_equiv(state_dict["y"][0][3, 2, 690:710], np.ones(20))
+        assert np.array_equiv(
+            state_dict["y"][0][2, 0, 190:210], np.ones(20)
+        )  # Entry with pick
+    else:
+        assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[1] == 500
+        assert np.argmax(state_dict["y"][0][3, :, :], axis=-1)[2] == 700
+        assert (
+            np.argmax(state_dict["y"][0][2, :, :], axis=-1)[0] == 200
+        )  # Entry with pick
+    assert (state_dict["y"][0][3, 0, :] == 0).all()
 
-            # Fails if single sample provided for multiple windows
-            state_dict = {
-                "X": (
-                    10 * np.random.rand(5, 3, 1000),
-                    {
-                        "trace_p_arrival_sample": 500,
-                        "trace_s_arrival_sample": 700,
-                    },
-                )
-            }
-            with pytest.raises(ValueError):
-                labeller = ProbabilisticLabeller(dim=1, shape=shape)
-                labeller(state_dict)
+    # Fails if single sample provided for multiple windows
+    state_dict = {
+        "X": (
+            10 * np.random.rand(5, 3, 1000),
+            {
+                "trace_p_arrival_sample": 500,
+                "trace_s_arrival_sample": 700,
+            },
+        )
+    }
+    with pytest.raises(ValueError):
+        labeller = ProbabilisticLabeller(dim=1, shape=shape)
+        labeller(state_dict)
 
-            state_dict["X"] = np.random.rand(10, 5, 3, 1000)
+    state_dict["X"] = np.random.rand(10, 5, 3, 1000)
 
-            # Fails if non-compatible input data dimensions are provided
-            with pytest.raises(ValueError):
-                labeller = ProbabilisticLabeller(dim=1, shape=shape)
-                labeller(state_dict)
+    # Fails if non-compatible input data dimensions are provided
+    with pytest.raises(ValueError):
+        labeller = ProbabilisticLabeller(dim=1, shape=shape)
+        labeller(state_dict)
 
 
 def test_step_labeller():
@@ -1504,7 +1503,7 @@ def test_add_gap():
 def test_add_gap_with_picks_in_gap():
     np.random.seed(42)
     # single window
-    gap = seisbench.generate.AddGap(axis=-1, picks_in_gap_thre=10)
+    gap = seisbench.generate.AddGap(axis=-1, picks_in_gap_threshold=10)
     with patch("numpy.random.randint") as randint:
         randint.side_effect = [400, 600]
         state_dict = {
@@ -1537,7 +1536,7 @@ def test_add_gap_with_picks_in_gap():
         ).all()  # After are non-zero entries
 
     # multiple windows
-    gap = seisbench.generate.AddGap(axis=-1, picks_in_gap_thre=10)
+    gap = seisbench.generate.AddGap(axis=-1, picks_in_gap_threshold=10)
     with patch("numpy.random.randint") as randint:
         randint.side_effect = [100, 200]
         state_dict = {


### PR DESCRIPTION
## Changes
1. Create an bool-type variable "noise_column" in the PickLabeller class to determine whether a noise label will be constructed. If the noise_column is false, no noise label will be created, and labels will not be normalized.
2. Update the `SupervisedLabeller::_check_labels()` function
3. Update `test_probabilistic_pick_labeller()`

## A visual example
```python
from seisbench.generate import ProbabilisticLabeller
import numpy as np
import matplotlib.pyplot as plt
np.random.seed(42)
p=50
s=100
state_dict = {
    "X": (
        10 * np.random.rand(3, 200),
        {
            "trace_p_arrival_sample": p,
            "trace_s_arrival_sample": s,
        },
    )
}
fig,axs=plt.subplots(4,2,sharex="all")

for i,noise_column in enumerate([True,False]):
    labeller = ProbabilisticLabeller(
        dim=0, shape="gaussian",sigma=20, noise_column=noise_column
    )
    labeller(state_dict)

    state_dict["y"][0].shape
    print(np.all(state_dict["y"][0]>=0))

    for j in range(3):
        ax=axs[j][i]
        ax.plot(state_dict["X"][0][j,:].T)
    axs[3][i].plot(state_dict["y"][0].T)
    axs[3][i].axvline(p,color="blue",label="True P")
    axs[3][i].axvline(s,color="red",label="True S")
axs[3][1].legend()
```
![image](https://github.com/seisbench/seisbench/assets/38816011/dbd78566-f9ab-4213-ac58-4f3cc552787a)

