### PR TITLE
Add an option for AddGap and ChannelDropout to modify label directly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,9 @@ repos:
     args: ['--maxkb=1000']
   - id: check-toml
   - id: check-json
-  - id: pretty-format-json
-    args: [--autofix]
+# Hook shows incompatibility with ipynb files
+#  - id: pretty-format-json
+#    args: [--autofix]
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/pycqa/isort

--- a/seisbench/generate/augmentation.py
+++ b/seisbench/generate/augmentation.py
@@ -453,13 +453,13 @@ class AddGap:
                 Otherwise, a 2-tuple is expected, with the first string indicating the key to
                 read from and the second one the key to write to.
     :type key: str, tuple[str, str]
-    :param meta_picks_in_gap_thre: If it is not None, check whether the picks in the metadata
+    :param metadata_picks_in_gap_threshold: If it is not None, check whether the picks in the metadata
                                    is within the gap. If a pick is within the gap and the
                                    distance from the pick to the gap border is larger than
-                                   `meta_picks_in_gap_thre` (unit: sample), the corresponding
+                                   `metadata_picks_in_gap_threshold` (unit: sample), the corresponding
                                    arrival sample in the metadata will be set to NaN.
                                    If it is None, the metadata will not be modified
-    :type meta_picks_in_gap_thre: int, None
+    :type metadata_picks_in_gap_threshold: int, None
     :param label_keys: Specify the labels to which the gap is applied
     :type label_keys: str, tuple[str,str], None
     :param noise_id: {key of labels containing noise --> index of the noise column}. For example,
@@ -472,7 +472,7 @@ class AddGap:
         self,
         axis=-1,
         key="X",
-        meta_picks_in_gap_thre=None,
+        metadata_picks_in_gap_threshold=None,
         label_keys=None,
         noise_id={"y": -1},
     ):
@@ -497,10 +497,10 @@ class AddGap:
                 self.label_keys.append((key, key))
         self.noise_id = noise_id
 
-        if isinstance(meta_picks_in_gap_thre, int):
-            self.meta_picks_in_gap_thre = meta_picks_in_gap_thre
+        if isinstance(metadata_picks_in_gap_threshold, int):
+            self.metadata_picks_in_gap_threshold = metadata_picks_in_gap_threshold
         else:
-            self.meta_picks_in_gap_thre = None
+            self.metadata_picks_in_gap_threshold = None
 
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key[0]]
@@ -528,14 +528,14 @@ class AddGap:
 
         np.put_along_axis(x, gap, 0, axis=axis)
 
-        if self.meta_picks_in_gap_thre is not None:
+        if self.metadata_picks_in_gap_threshold is not None:
             for key in metadata.keys():
                 if key.endswith("_arrival_sample"):
                     if isinstance(metadata[key], (int, np.integer, float)):
                         # Handle single window case
                         if (
                             min(metadata[key] - gap_start, gap_end - 1 - metadata[key])
-                            >= self.meta_picks_in_gap_thre
+                            >= self.metadata_picks_in_gap_threshold
                         ):
                             metadata[key] = np.nan
                     else:
@@ -546,7 +546,7 @@ class AddGap:
                                     metadata[key][j] - gap_start,
                                     gap_end - 1 - metadata[key][j],
                                 )
-                                >= self.meta_picks_in_gap_thre
+                                >= self.metadata_picks_in_gap_threshold
                             ):
                                 try:
                                     metadata[key][j] = np.nan

--- a/seisbench/generate/augmentation.py
+++ b/seisbench/generate/augmentation.py
@@ -349,19 +349,46 @@ class ChannelDropout:
                 Otherwise, a 2-tuple is expected, with the first string indicating the key to
                 read from and the second one the key to write to.
     :type key: str, tuple[str, str]
-    :param check_picks_in_gap: If true, check whether all channels are zero after channel
-                               dropping and if so, set phase arrivals to NaN.
-    :type check_picks_in_gap: bool
+    :param check_meta_picks_in_gap: If true, check whether all channels are zero after channel
+                                    dropping and if so, set phase arrivals to NaN.
+    :type check_meta_picks_in_gap: bool
+    :param label_keys: Specify the labels to which the gap is applied
+    :type label_keys: str, tuple[str,str], None
+    :param noise_id: {key of labels containing noise --> index of the noise column}. For example,
+                     `noise_id={"y", -1}` indicate that `state_dict["y"][0][..., -1, ...]` is the
+                     noise label.
+    :type noise_id: dict
     """
 
-    def __init__(self, axis=-2, key="X", check_picks_in_gap=False):
+    def __init__(
+        self,
+        axis=-2,
+        key="X",
+        check_meta_picks_in_gap=False,
+        label_keys=None,
+        noise_id={"y": -1},
+    ):
         if isinstance(key, str):
             self.key = (key, key)
         else:
             self.key = key
 
+        if not isinstance(label_keys, list):
+            if label_keys is None:
+                label_keys = []
+            else:
+                label_keys = [label_keys]
+
+        self.label_keys = []
+        for key in label_keys:
+            if isinstance(key, tuple):
+                self.label_keys.append(key)
+            else:
+                self.label_keys.append((key, key))
+        self.noise_id = noise_id
+
         self.axis = axis
-        self.check_picks_in_gap = check_picks_in_gap
+        self.check_meta_picks_in_gap = check_meta_picks_in_gap
 
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key[0]]
@@ -390,7 +417,7 @@ class ChannelDropout:
                     drop_channels = np.expand_dims(drop_channels, -1)
 
             np.put_along_axis(x, drop_channels, 0, axis=axis)
-            if self.check_picks_in_gap:
+            if self.check_meta_picks_in_gap:
                 if np.allclose(x, 0):
                     # if all channels are zeros, ignore original phase arrivals
                     for key in metadata.keys():
@@ -401,6 +428,16 @@ class ChannelDropout:
                             else:
                                 # multi-window case
                                 metadata[key] = [np.nan] * len(metadata[key])
+            if self.label_keys:
+                if np.allclose(x, 0):
+                    for label_key in self.label_keys:
+                        y, _ = state_dict[label_key[0]]
+                        if label_key[0] != label_key[1]:
+                            y = y.copy()
+                        y[...] = 0
+                        if label_key[0] in self.noise_id:
+                            y[..., self.noise_id[label_key[0]], :] = 1
+                        state_dict[label_key[1]] = (y, copy.deepcopy(metadata))
 
         state_dict[self.key[1]] = (x, metadata)
 
@@ -416,15 +453,29 @@ class AddGap:
                 Otherwise, a 2-tuple is expected, with the first string indicating the key to
                 read from and the second one the key to write to.
     :type key: str, tuple[str, str]
-    :param picks_in_gap_thre: If a pick is within the gap and the distance from the pick to the
-                              gap border is larger than `picks_in_gap_thre` (unit: sample), this
-                              pick will be ignored and the corresponding arrival sample in the
-                              metadata will be set to NaN. If `picks_in_gap_thre` is None, skip
-                              the check.
-    :type picks_in_gap_thre: int, None
+    :param meta_picks_in_gap_thre: If it is not None, check whether the picks in the metadata
+                                   is within the gap. If a pick is within the gap and the
+                                   distance from the pick to the gap border is larger than
+                                   `meta_picks_in_gap_thre` (unit: sample), the corresponding
+                                   arrival sample in the metadata will be set to NaN.
+                                   If it is None, the metadata will not be modified
+    :type meta_picks_in_gap_thre: int, None
+    :param label_keys: Specify the labels to which the gap is applied
+    :type label_keys: str, tuple[str,str], None
+    :param noise_id: {key of labels containing noise --> index of the noise column}. For example,
+                     `noise_id={"y", -1}` indicate that `state_dict["y"][0][..., -1, ...]` is the
+                     noise label.
+    :type noise_id: dict
     """
 
-    def __init__(self, axis=-1, key="X", picks_in_gap_thre=None):
+    def __init__(
+        self,
+        axis=-1,
+        key="X",
+        meta_picks_in_gap_thre=None,
+        label_keys=None,
+        noise_id={"y": -1},
+    ):
         if isinstance(key, str):
             self.key = (key, key)
         else:
@@ -432,10 +483,24 @@ class AddGap:
 
         self.axis = axis
 
-        if isinstance(picks_in_gap_thre, int):
-            self.picks_in_gap_thre = picks_in_gap_thre
+        if not isinstance(label_keys, list):
+            if label_keys is None:
+                label_keys = []
+            else:
+                label_keys = [label_keys]
+
+        self.label_keys = []
+        for key in label_keys:
+            if isinstance(key, tuple):
+                self.label_keys.append(key)
+            else:
+                self.label_keys.append((key, key))
+        self.noise_id = noise_id
+
+        if isinstance(meta_picks_in_gap_thre, int):
+            self.meta_picks_in_gap_thre = meta_picks_in_gap_thre
         else:
-            self.picks_in_gap_thre = None
+            self.meta_picks_in_gap_thre = None
 
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key[0]]
@@ -462,14 +527,15 @@ class AddGap:
                 gap = np.expand_dims(gap, -1)
 
         np.put_along_axis(x, gap, 0, axis=axis)
-        if self.picks_in_gap_thre is not None:
+
+        if self.meta_picks_in_gap_thre is not None:
             for key in metadata.keys():
                 if key.endswith("_arrival_sample"):
                     if isinstance(metadata[key], (int, np.integer, float)):
                         # Handle single window case
                         if (
                             min(metadata[key] - gap_start, gap_end - 1 - metadata[key])
-                            >= self.picks_in_gap_thre
+                            >= self.meta_picks_in_gap_thre
                         ):
                             metadata[key] = np.nan
                     else:
@@ -480,7 +546,7 @@ class AddGap:
                                     metadata[key][j] - gap_start,
                                     gap_end - 1 - metadata[key][j],
                                 )
-                                >= self.picks_in_gap_thre
+                                >= self.meta_picks_in_gap_thre
                             ):
                                 try:
                                     metadata[key][j] = np.nan
@@ -488,6 +554,16 @@ class AddGap:
                                     metadata[key] = metadata[key].astype(np.float64)
                                     metadata[key][j] = np.nan
         state_dict[self.key[1]] = (x, metadata)
+
+        for label_key in self.label_keys:
+            y, _ = state_dict[label_key[0]]
+            if label_key[0] != label_key[1]:
+                y = y.copy()
+            np.put_along_axis(y, gap, 0, axis=axis)
+            if label_key[0] in self.noise_id:
+                y[..., self.noise_id[label_key[0]], gap] = 1
+
+            state_dict[label_key[1]] = (y, copy.deepcopy(metadata))
 
 
 class RandomArrayRotation:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1414,7 +1414,7 @@ def test_channel_dropout_with_picks_in_gap():
     np.random.seed(42)  # With seed 42, the channels 1 and 2 will be dropped
     # single window
     dropout = seisbench.generate.ChannelDropout(
-        axis=0, check_picks_in_gap=True
+        axis=0, check_meta_picks_in_gap=True
     )  # Positively defined axis
     state_dict = {
         "X": (
@@ -1464,6 +1464,76 @@ def test_channel_dropout_with_picks_in_gap():
     assert np.allclose(state_dict["y"][0][:, 0:2, :], 0)
 
 
+def test_channel_dropout_modify_labels_directly():
+    # modify labels directly
+    np.random.seed(42)  # With seed 42, the channels 1 and 2 will be dropped
+    # single window
+    dropout = seisbench.generate.ChannelDropout(
+        axis=0, label_keys=["y", "detections"], check_meta_picks_in_gap=False
+    )  # Positively defined axis
+    state_dict = {
+        "X": (
+            10 * np.random.rand(3, 1000),
+            {
+                "trace_p_arrival_sample": 500,
+                "trace_s_arrival_sample": 590,
+            },
+        )
+    }
+    state_dict["X"][0][0, :] = 0  # set the first component to zeros
+    assert not np.allclose(state_dict["X"][0], 0)
+
+    labeller = ProbabilisticLabeller(dim=-2, noise_column=True)
+    detection_labeller = DetectionLabeller(
+        p_phases=["trace_p_arrival_sample"],
+        s_phases=["trace_s_arrival_sample"],
+        key=("X", "detections"),
+        factor=1.4,
+    )
+    labeller(state_dict)
+    detection_labeller(state_dict)
+    dropout(state_dict)
+
+    assert state_dict["y"][0].shape == (3, 1000)
+    assert state_dict["detections"][0].shape == (1, 1000)
+    assert np.allclose(state_dict["X"][0], 0)  # waveform
+    assert np.allclose(state_dict["y"][0][..., 0:-1, :], 0)  # p and s, 0
+    assert np.allclose(state_dict["y"][0][..., -1, :], 1)  # noise, 1
+    assert np.allclose(state_dict["detections"][0], 0)  # detections, 0
+
+    # multiple windows
+    dropout = seisbench.generate.ChannelDropout(
+        axis=-2, label_keys=["y", "detections"], check_meta_picks_in_gap=False
+    )
+    state_dict = {
+        "X": (
+            10 * np.random.rand(5, 3, 1000),
+            {
+                "trace_p_arrival_sample": np.array([150, 190, 300, 400, 500]),
+                "trace_s_arrival_sample": np.array([180, 250, 350, np.nan, 550]),
+            },
+        )
+    }
+    state_dict["X"][0][:, 0, :] = 0
+    assert not np.allclose(state_dict["X"][0], 0)
+    labeller = ProbabilisticLabeller(dim=-2, noise_column=True)
+    detection_labeller = DetectionLabeller(
+        p_phases=["trace_p_arrival_sample"],
+        s_phases=["trace_s_arrival_sample"],
+        key=("X", "detections"),
+        factor=1.4,
+    )
+    labeller(state_dict)
+    detection_labeller(state_dict)
+    dropout(state_dict)
+
+    assert state_dict["y"][0].shape == (5, 3, 1000)
+    assert state_dict["detections"][0].shape == (5, 1, 1000)
+    assert np.allclose(state_dict["y"][0][..., 0:-1, :], 0)  # p and s, 0
+    assert np.allclose(state_dict["y"][0][..., -1, :], 1)  # noise, 1
+    assert np.allclose(state_dict["detections"][0], 0)  # detections 0
+
+
 def test_add_gap():
     np.random.seed(42)
 
@@ -1504,7 +1574,7 @@ def test_add_gap():
 def test_add_gap_with_picks_in_gap():
     np.random.seed(42)
     # single window
-    gap = seisbench.generate.AddGap(axis=-1, picks_in_gap_thre=10)
+    gap = seisbench.generate.AddGap(axis=-1, meta_picks_in_gap_thre=10)
     with patch("numpy.random.randint") as randint:
         randint.side_effect = [400, 600]
         state_dict = {
@@ -1537,7 +1607,7 @@ def test_add_gap_with_picks_in_gap():
         ).all()  # After are non-zero entries
 
     # multiple windows
-    gap = seisbench.generate.AddGap(axis=-1, picks_in_gap_thre=10)
+    gap = seisbench.generate.AddGap(axis=-1, meta_picks_in_gap_thre=10)
     with patch("numpy.random.randint") as randint:
         randint.side_effect = [100, 200]
         state_dict = {
@@ -1566,6 +1636,130 @@ def test_add_gap_with_picks_in_gap():
         assert not (
             state_dict["X"][0][:, :, 200:] == 0
         ).all()  # After are non-zero entries
+
+
+def test_add_gap_to_waveform_and_labels():
+    np.random.seed(42)
+    gap = seisbench.generate.AddGap(
+        axis=-1, label_keys=["y", "detections"], meta_picks_in_gap_thre=None
+    )  # Negatively defined axis
+    with patch("numpy.random.randint") as randint:
+        randint.side_effect = [400, 600]
+        state_dict = {
+            "X": (
+                10 * np.random.rand(3, 1000),
+                {
+                    "trace_p_arrival_sample": 399,
+                    "trace_s_arrival_sample": 600,
+                },
+            )
+        }
+        assert not np.isnan(state_dict["X"][1]["trace_p_arrival_sample"])
+        assert not np.isnan(state_dict["X"][1]["trace_s_arrival_sample"])
+
+        labeller = ProbabilisticLabeller(dim=-2, noise_column=True)
+        detection_labeller = DetectionLabeller(
+            p_phases=["trace_p_arrival_sample"],
+            s_phases=["trace_s_arrival_sample"],
+            key=("X", "detections"),
+            factor=1.4,
+        )
+        labeller(state_dict)
+        detection_labeller(state_dict)
+
+        gap(state_dict)
+
+        assert np.allclose(np.sum(state_dict["y"][0], axis=0, keepdims=True), 1)
+
+        # check shapes
+        assert state_dict["X"][0].shape == (3, 1000)
+        assert state_dict["y"][0].shape == (3, 1000)
+        assert state_dict["detections"][0].shape == (1, 1000)
+
+        # check waveform samples
+        assert (state_dict["X"][0][:, 400:600] == 0).all()  # Correct part is blinded
+        assert not (
+            state_dict["X"][0][:, :400] == 0
+        ).all()  # Before are non-zero entries
+        assert not (
+            state_dict["X"][0][:, 600:] == 0
+        ).all()  # After are non-zero entries
+
+        # check p/s/noise labels
+        assert np.allclose(state_dict["y"][0][0, 400:600], 0)  # p within the gap
+        assert np.allclose(state_dict["y"][0][1, 400:600], 0)  # s within the gap
+        assert np.allclose(state_dict["y"][0][2, 400:600], 1)  # noise within the gap
+
+        assert np.isclose(state_dict["y"][0][0, 399], 1)  # p
+        assert np.isclose(state_dict["y"][0][1, 600], 1)  # s
+
+        # check detection label
+        assert (state_dict["detections"][0][:, 400:600] == 0).all()
+        assert (
+            state_dict["detections"][0][:, 600 : int(600 + (600 - 399) * 1.4)] == 1
+        ).all()
+        assert state_dict["detections"][0][:, 399] == 1
+
+    # multiple windows
+    gap = seisbench.generate.AddGap(
+        axis=-1, label_keys=["y", "detections"], meta_picks_in_gap_thre=5
+    )
+    with patch("numpy.random.randint") as randint:
+        randint.side_effect = [100, 200]
+        state_dict = {
+            "X": (
+                10 * np.random.rand(5, 3, 1000),
+                {
+                    "trace_p_arrival_sample": np.array([110, 150, 50, 300, 500]),
+                    "trace_s_arrival_sample": np.array([210, 300, 190, 400, 550]),
+                },
+            )
+        }
+
+        labeller = ProbabilisticLabeller(dim=-2, noise_column=True, sigma=10)
+        detection_labeller = DetectionLabeller(
+            p_phases=["trace_p_arrival_sample"],
+            s_phases=["trace_s_arrival_sample"],
+            key=("X", "detections"),
+            factor=1.4,
+        )
+        labeller(state_dict)
+        detection_labeller(state_dict)
+        gap(state_dict)
+
+        assert np.isnan(state_dict["X"][1]["trace_p_arrival_sample"][0])
+        assert np.isnan(state_dict["X"][1]["trace_p_arrival_sample"][1])
+        assert np.isnan(state_dict["X"][1]["trace_s_arrival_sample"][2])
+
+        assert np.isclose(state_dict["y"][0][1, 0, 150], 0)
+        assert np.isclose(state_dict["y"][0][1, 1, 300], 1)
+
+        # check shapes
+        assert state_dict["X"][0].shape == (5, 3, 1000)
+        assert state_dict["y"][0].shape == (5, 3, 1000)
+
+        # check waveform samples
+        assert (state_dict["X"][0][..., 100:200] == 0).all()  # Correct part is blinded
+        assert not (
+            state_dict["X"][0][:, :, :100] == 0
+        ).all()  # Before are non-zero entries
+        assert not (
+            state_dict["X"][0][:, :, 200:] == 0
+        ).all()  # After are non-zero entries
+
+        # check labels
+        assert (state_dict["y"][0][:, :-1, 100:200] == 0).all()  # p and s labels
+        assert (state_dict["y"][0][:, -1, 100:200] == 1).all()  # noise
+        assert np.allclose(np.sum(state_dict["y"][0], axis=1, keepdims=True), 1)
+
+        assert (state_dict["detections"][0][:, :, 100:200] == 0).all()
+        assert (
+            state_dict["detections"][0][0, :, 200 : int(210 + (210 - 110) * 1.4)] == 1
+        ).all()
+        assert (state_dict["detections"][0][2, :, 50:100] == 1).all()
+        assert (
+            state_dict["detections"][0][2, :, 200 : int(190 + (190 - 50) * 1.4)] == 1
+        ).all()
 
 
 def test_random_array_rotation_keys():


### PR DESCRIPTION
In pull request https://github.com/seisbench/seisbench/pull/222, only the metadata is changed if there is any pick in a gap.

It may be helpful to add an option to change labels directly. For example. when one waveform is staked on another (e.g. [benchmark/augmentations.py](https://github.com/seisbench/pick-benchmark/blob/main/benchmark/augmentations.py)) to generate a new trace, the metadata is kept unchanged and only the label is changed. In this case, adding the gap to the labels directly is a better choice.

- I added two label_keys `label_keys` and `noise_id` to `AddGap` and `ChannelDropout`
- Two new tests: `test_channel_dropout_with_picks_in_gap` and `test_add_gap_to_waveform_and_labels`

I forgot to pull your commit at the beginning, so I manually resolved the conflicts. I hope it didn't break the commits b253784a084a10ed8af19950e780999e3118fd06 and 319d9447e71cf92033d5653560cb180c48209858
