### PR TITLE
Python 3.12 (Closes #263)

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0  # Fetched tags too
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.12'
 
       - name: Install setuptools
         run: pip install build  --user


### PR DESCRIPTION
- Add Python 3.12 to CI
- Switch publishing workflow to Python 3.12 to avoid future deprecation issues