### PR TITLE
Bugfix for PhaseNet label IDs

### DIFF
--- a/seisbench/generate/labeling.py
+++ b/seisbench/generate/labeling.py
@@ -143,7 +143,7 @@ class PickLabeller(SupervisedLabeller, ABC):
                 self.labels,
                 self.label_ids,
             ) = self._colums_to_dict_and_labels(
-                label_columns, noise_column=noise_column, model_labels=self.model_labels
+                label_columns, noise_column=noise_column, model_labels=model_labels
             )
         else:
             self.labels = None

--- a/seisbench/generate/labeling.py
+++ b/seisbench/generate/labeling.py
@@ -131,16 +131,19 @@ class PickLabeller(SupervisedLabeller, ABC):
     :param kwargs: Kwargs are passed to the SupervisedLabeller superclass
     """
 
-    def __init__(self, label_columns=None, noise_column=True, **kwargs):
+    def __init__(
+        self, label_columns=None, noise_column=True, model_labels=None, **kwargs
+    ):
         self.label_columns = label_columns
         self.noise_column = noise_column
+        self.model_labels = model_labels
         if label_columns is not None:
             (
                 self.label_columns,
                 self.labels,
                 self.label_ids,
             ) = self._colums_to_dict_and_labels(
-                label_columns, noise_column=noise_column
+                label_columns, noise_column=noise_column, model_labels=self.model_labels
             )
         else:
             self.labels = None
@@ -159,7 +162,7 @@ class PickLabeller(SupervisedLabeller, ABC):
         )
 
     @staticmethod
-    def _colums_to_dict_and_labels(label_columns, noise_column=True):
+    def _colums_to_dict_and_labels(label_columns, noise_column=True, model_labels=None):
         """
         Generate label columns dict and list of labels from label_columns list or dict.
         Always appends a noise column at the end.
@@ -171,9 +174,18 @@ class PickLabeller(SupervisedLabeller, ABC):
             label_columns = {label: label.split("_")[1] for label in label_columns}
 
         labels = sorted(list(np.unique(list(label_columns.values()))))
-        if noise_column:
-            labels.append("Noise")
-        label_ids = {label: i for i, label in enumerate(labels)}
+
+        if model_labels:
+            label_ids = {
+                label: [*model_labels].index(label) for label in labels
+            }  # label ids for P and S
+            if noise_column:
+                label_ids["Noise"] = len(model_labels) - sum(list(label_ids.values()))
+                labels.append("Noise")
+        else:
+            if noise_column:
+                labels.append("Noise")
+            label_ids = {label: i for i, label in enumerate(labels)}
 
         return label_columns, labels, label_ids
 
@@ -216,7 +228,9 @@ class ProbabilisticLabeller(PickLabeller):
                 self.label_columns,
                 self.labels,
                 self.label_ids,
-            ) = self._colums_to_dict_and_labels(label_columns, self.noise_column)
+            ) = self._colums_to_dict_and_labels(
+                label_columns, self.noise_column, self.model_labels
+            )
 
         sample_dim, channel_dim, width_dim = self._get_dimension_order_from_config(
             config, self.ndim
@@ -323,7 +337,9 @@ class StepLabeller(PickLabeller):
                 self.label_columns,
                 self.labels,
                 self.label_ids,
-            ) = self._colums_to_dict_and_labels(label_columns, noise_column=False)
+            ) = self._colums_to_dict_and_labels(
+                label_columns, noise_column=False, model_labels=self.model_labels
+            )
 
         sample_dim, channel_dim, width_dim = self._get_dimension_order_from_config(
             config, self.ndim
@@ -676,7 +692,9 @@ class StandardLabeller(PickLabeller):
                 self.label_columns,
                 self.labels,
                 self.label_ids,
-            ) = self._colums_to_dict_and_labels(label_columns)
+            ) = self._colums_to_dict_and_labels(
+                label_columns, model_labels=self.model_labels
+            )
 
         sample_dim, _, width_dim = self._get_dimension_order_from_config(
             config, self.ndim

--- a/seisbench/generate/labeling.py
+++ b/seisbench/generate/labeling.py
@@ -168,6 +168,9 @@ class PickLabeller(SupervisedLabeller, ABC):
         Always appends a noise column at the end.
 
         :param label_columns: List of label columns or dict[label_columns -> labels]
+        :param noise_column: If False, disables normalization of phases and noise label, default is True
+        :param model_labels: Phase labels of the loaded or created model, default is None.
+                             Get labels from model by model.labels
         :return: dict[label_columns -> labels], list[labels], dict[labels -> ids]
         """
         if not isinstance(label_columns, dict):

--- a/seisbench/generate/labeling.py
+++ b/seisbench/generate/labeling.py
@@ -80,19 +80,19 @@ class SupervisedLabeller(ABC):
 
         return sample_dim, channel_dim, width_dim
 
-    def _check_labels(self, y, metadata):
+    def _check_labels(self, y, metadata, eps=1e-8):
         if (
             self.label_type == "multi_class"
             and self.label_method == "probabilistic"
             and getattr(self, "noise_column", True)
         ):
-            if (y.sum(self.dim) > 1).any():
+            if (y.sum(self.dim) > 1 + eps).any():
                 raise ValueError(
                     f"More than one label provided. For multi_class problems, only one label can be provided per input."
                 )
 
         if self.label_type == "binary":
-            if (y.sum(self.dim) > 1).any():
+            if (y.sum(self.dim) > 1 + eps).any():
                 raise ValueError(f"Binary labels should lie within 0-1 range.")
 
         for label in self.label_columns:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1051,14 +1051,21 @@ def test_standard_pick_labeller_pickgroups():
         labeller(state_dict)
 
 
-def test_colums_to_dict_and_labels():
+@pytest.mark.parametrize(
+    "model_labels",
+    [
+        "psn",
+        "nps",
+    ],
+)
+def test_colums_to_dict_and_labels(model_labels):
     label_columns = ["trace_p_arrival_sample", "trace_s_arrival_sample"]
     (
         label_columns,
         labels,
         label_ids,
     ) = seisbench.generate.labeling.PickLabeller._colums_to_dict_and_labels(
-        label_columns
+        label_columns, model_labels=model_labels
     )
 
     assert label_columns == {
@@ -1066,7 +1073,10 @@ def test_colums_to_dict_and_labels():
         "trace_s_arrival_sample": "s",
     }
     assert labels == ["p", "s", "Noise"]
-    assert label_ids == {"p": 0, "s": 1, "Noise": 2}
+    if model_labels == "psn":
+        assert label_ids == {"p": 0, "s": 1, "Noise": 2}
+    elif model_labels == "nps":
+        assert label_ids == {"Noise": 0, "p": 1, "s": 2}
 
     label_columns = {
         "trace_p_arrival_sample": "p",

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1061,7 +1061,7 @@ def test_colums_to_dict_and_labels(model_labels):
         label_columns,
         labels,
         label_ids,
-    ) = seisbench.generate.labeling.PickLabeller._colums_to_dict_and_labels(
+    ) = seisbench.generate.labeling.PickLabeller._columns_to_dict_and_labels(
         label_columns, model_labels=model_labels
     )
 
@@ -1086,7 +1086,7 @@ def test_colums_to_dict_and_labels(model_labels):
         label_columns,
         labels,
         label_ids,
-    ) = seisbench.generate.labeling.PickLabeller._colums_to_dict_and_labels(
+    ) = seisbench.generate.labeling.PickLabeller._columns_to_dict_and_labels(
         label_columns
     )
 
@@ -1097,6 +1097,31 @@ def test_colums_to_dict_and_labels(model_labels):
     }
     assert labels == ["p", "s", "Noise"]
     assert label_ids == {"p": 0, "s": 1, "Noise": 2}
+
+
+@pytest.mark.parametrize(
+    "noise_column",
+    [True, False],
+)
+def test_colums_to_dict_and_labels_noise_column(noise_column):
+    model_labels = "ebcad"
+    label_columns = [f"trace_{x}_arrival" for x in model_labels]
+    (
+        label_columns,
+        labels,
+        label_ids,
+    ) = seisbench.generate.labeling.PickLabeller._columns_to_dict_and_labels(
+        label_columns, model_labels=model_labels, noise_column=noise_column
+    )
+
+    if noise_column:
+        assert label_columns == {f"trace_{x}_arrival": x for x in model_labels}
+        assert labels == [*sorted(model_labels), "Noise"]
+        assert label_ids == {"e": 0, "b": 1, "c": 2, "a": 3, "d": 4, "Noise": 5}
+    else:
+        assert label_columns == {f"trace_{x}_arrival": x for x in model_labels}
+        assert labels == [*sorted(model_labels)]
+        assert label_ids == {"e": 0, "b": 1, "c": 2, "a": 3, "d": 4}
 
 
 def test_swap_dimension_order():

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1053,10 +1053,7 @@ def test_standard_pick_labeller_pickgroups():
 
 @pytest.mark.parametrize(
     "model_labels",
-    [
-        "psn",
-        "nps",
-    ],
+    ["psn", "nps", None],
 )
 def test_colums_to_dict_and_labels(model_labels):
     label_columns = ["trace_p_arrival_sample", "trace_s_arrival_sample"]
@@ -1077,6 +1074,8 @@ def test_colums_to_dict_and_labels(model_labels):
         assert label_ids == {"p": 0, "s": 1, "Noise": 2}
     elif model_labels == "nps":
         assert label_ids == {"Noise": 0, "p": 1, "s": 2}
+    else:
+        assert label_ids == {"p": 0, "s": 1, "Noise": 2}
 
     label_columns = {
         "trace_p_arrival_sample": "p",


### PR DESCRIPTION
Hi Jannes,

when using the original PhaseNet model or diting as base models for transfer learning, the label IDs are wrong. Default labels_ids are {"P": 0, "S": 1, "Noise": 2}, however, PhaseNet and diting have {"Noise": 0, "P": 1, "S": 2}. Therefore, transfer learning was not possible since the ids did not depend on the given labels by the loaded model. I rewrote the method "_colums_to_dict_and_labels" and added an argument model_labels to get the correct dictionary and label IDs.

Cheers,
Janis