### PR TITLE
Change annotate logic from windowed to batched pre- and postprocessing

### DIFF
--- a/contrib/benchmark_model_annotate.py
+++ b/contrib/benchmark_model_annotate.py
@@ -1,0 +1,44 @@
+"""
+This is a minimalist benchmark to compare different versions of the annotate function
+"""
+
+import time
+
+import numpy as np
+import obspy
+
+import seisbench.models as sbm
+
+
+def main(n_stations: int = 2, n_samples: int = 8640000):
+    models = [sbm.PhaseNetLight(), sbm.PhaseNet(), sbm.EQTransformer()]
+    # models = [sbm.PhaseNet()]
+
+    data = obspy.Stream()
+    for sid in range(n_stations):
+        for c in "ZNE":
+            data.append(
+                obspy.Trace(
+                    np.random.rand(n_samples),
+                    header={
+                        "network": "CX",
+                        "station": f"S{sid:04d}",
+                        "location": "",
+                        "channel": f"HH{c}",
+                        "sampling_rate": 100.0,
+                    },
+                )
+            )
+
+    for model in models:
+        # model.cuda()
+        # Warmup
+        models[0].annotate(data[:3])
+        t0 = time.time()
+        model.annotate(data, batch_size=1024, copy=False)
+        t1 = time.time()
+        print(model.__class__.__name__, t1 - t0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/pages/documentation/util.rst
+++ b/docs/pages/documentation/util.rst
@@ -48,3 +48,11 @@ Auxiliary functions
     :members:
     :undoc-members:
     :show-inheritance:
+
+Array tools
+------------------------------------------------------------
+
+.. automodule:: seisbench.util.arraytools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -1154,7 +1154,7 @@ class WaveformDataset:
 
         if pack:
             waveforms = [waveforms[segment] for segment in segments]
-            waveforms = self._pad_packed_sequence(waveforms)
+            waveforms = seisbench.util.pad_packed_sequence(waveforms)
 
             # Impose correct dimension order
             waveforms = waveforms.transpose(*self._dimension_mapping)
@@ -1425,29 +1425,6 @@ class WaveformDataset:
                     / source_sampling_rate
                 )
                 return scipy.signal.resample(waveform, num, axis=sample_axis)
-
-    @staticmethod
-    def _pad_packed_sequence(seq):
-        """
-        Packs a list of arrays into one array by adding a new first dimension and padding where necessary.
-
-        :param seq:
-        :return:
-        """
-        max_size = np.array(
-            [max([x.shape[i] for x in seq]) for i in range(seq[0].ndim)]
-        )
-
-        new_seq = []
-        for i, elem in enumerate(seq):
-            d = max_size - np.array(elem.shape)
-            if (d != 0).any():
-                pad = [(0, d_dim) for d_dim in d]
-                new_seq.append(np.pad(elem, pad, "constant", constant_values=0))
-            else:
-                new_seq.append(elem)
-
-        return np.stack(new_seq, axis=0)
 
     def plot_map(self, res="110m", connections=False, **kwargs):
         """

--- a/seisbench/models/deepdenoiser.py
+++ b/seisbench/models/deepdenoiser.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import scipy.signal
 import torch
@@ -74,6 +76,33 @@ class DeepDenoiser(WaveformModel):
         # Simply use channel as label
         return stations[0].split(".")[-1]
 
+    def annotate_batch_pre(
+        self, batch: torch.Tensor, argdict: dict[str, Any]
+    ) -> torch.Tensor:
+        # Reproduces scipy.signal.stft(window, fs=self.sampling_rate, nperseg=30, nfft=60, boundary="zeros")
+        # Note that the outputs need to be rotated by a factor of i ** dim to match numpy
+        tmp_signal = (
+            2
+            / 30
+            * torch.stft(
+                batch,
+                n_fft=60,
+                return_complex=True,
+                win_length=30,
+                window=torch.hann_window(30),
+                pad_mode="constant",
+                normalized=False,
+            )
+            * torch.pow(1j, torch.arange(31, device=batch.device)).unsqueeze(-1)
+        )
+
+        noisy_signal = torch.stack([tmp_signal.real, tmp_signal.imag], dim=1)
+
+        noisy_signal[torch.isnan(noisy_signal)] = 0
+        noisy_signal[torch.isinf(noisy_signal)] = 0
+
+        return self._normalize_batch(noisy_signal), noisy_signal
+
     def annotate_window_pre(self, window, argdict):
         f, t, tmp_signal = scipy.signal.stft(
             window, fs=self.sampling_rate, nperseg=30, nfft=60, boundary="zeros"
@@ -83,10 +112,74 @@ class DeepDenoiser(WaveformModel):
         noisy_signal[np.isnan(noisy_signal)] = 0
         noisy_signal[np.isinf(noisy_signal)] = 0
 
-        return self._normalize_batch(noisy_signal), noisy_signal
+        return self._normalize_batch_numpy(noisy_signal), noisy_signal
 
     @staticmethod
-    def _normalize_batch(data, window=200):
+    def _normalize_batch(data: torch.Tensor, window: int = 200) -> torch.Tensor:
+        """
+        Adapted from original DeepDenoiser implementation available at
+        https://github.com/wayneweiqiang/DeepDenoiser/blob/7bd9284ece73e25c99db2ad101aacda2a215a41a/deepdenoiser/app.py#L72
+
+        data shape: 2, nf, nt
+        data: nbn, nf, nt, 2
+        """
+        data = data.permute(0, 2, 3, 1)  # nbn, nf, nt, 2
+        assert len(data.shape) == 4
+        shift = window // 2
+        nbt, nf, nt, nimg = data.shape
+
+        # std in slide windows
+        data_pad = torch.nn.functional.pad(
+            data, (0, 0, window // 2, window // 2), mode="reflect"
+        )
+        t = torch.arange(
+            0, nt + shift - 1, shift, device=data.device
+        )  # 201 => 0, 100, 200
+
+        std = torch.zeros([nbt, len(t)])
+        mean = torch.zeros([nbt, len(t)])
+        for i in range(std.shape[1]):
+            std[:, i] = torch.std(
+                data_pad[:, :, i * shift : i * shift + window, :], axis=(1, 2, 3)
+            )
+            mean[:, i] = torch.mean(
+                data_pad[:, :, i * shift : i * shift + window, :], axis=(1, 2, 3)
+            )
+
+        std[:, -1], mean[:, -1] = std[:, -2], mean[:, -2]
+        std[:, 0], mean[:, 0] = std[:, 1], mean[:, 1]
+
+        # normalize data with interpolated std
+        interp_matrix = torch.zeros(3, 201, dtype=std.dtype, device=std.device)
+        interp_matrix[0, :101] = 1 - torch.linspace(
+            0, 1, 101, dtype=std.dtype, device=std.device
+        )
+        interp_matrix[1, :101] = torch.linspace(
+            0, 1, 101, dtype=std.dtype, device=std.device
+        )
+        interp_matrix[1, 100:] = 1 - torch.linspace(
+            0, 1, 101, dtype=std.dtype, device=std.device
+        )
+        interp_matrix[2, 100:] = torch.linspace(
+            0, 1, 101, dtype=std.dtype, device=std.device
+        )
+        std_interp = std @ interp_matrix
+        std_interp[std_interp == 0] = 1.0
+        mean_interp = mean @ interp_matrix
+
+        data = (data - mean_interp[:, np.newaxis, :, np.newaxis]) / std_interp[
+            :, np.newaxis, :, np.newaxis
+        ]
+
+        if len(t) > 3:  # need to address this normalization issue in training
+            data /= 2.0
+
+        data = data.permute(0, 3, 1, 2)  # 1 (nbt), 2, nf, nt
+
+        return data
+
+    @staticmethod
+    def _normalize_batch_numpy(data, window=200):
         """
         Adapted from original DeepDenoiser implementation available at
         https://github.com/wayneweiqiang/DeepDenoiser/blob/7bd9284ece73e25c99db2ad101aacda2a215a41a/deepdenoiser/app.py#L72
@@ -136,6 +229,24 @@ class DeepDenoiser(WaveformModel):
         data = data[0]  # Remove batch dim
 
         return data
+
+    def annotate_batch_post(
+        self, batch: torch.Tensor, piggyback: Any, argdict: dict[str, Any]
+    ) -> torch.Tensor:
+        signal = (piggyback[:, 0] + piggyback[:, 1] * 1j) * batch[:, 0]
+        signal = signal / torch.pow(
+            1j, torch.arange(signal.shape[-2], device=signal.device).unsqueeze(-1)
+        )
+
+        denoised_signal = 15 * torch.istft(
+            signal,
+            n_fft=60,
+            win_length=30,
+            window=torch.hann_window(30),
+            normalized=False,
+        )
+
+        return denoised_signal
 
     def annotate_window_post(self, pred, piggyback=None, argdict=None):
         noisy_signal = piggyback

--- a/seisbench/models/deepdenoiser.py
+++ b/seisbench/models/deepdenoiser.py
@@ -89,7 +89,7 @@ class DeepDenoiser(WaveformModel):
                 n_fft=60,
                 return_complex=True,
                 win_length=30,
-                window=torch.hann_window(30),
+                window=torch.hann_window(30).to(batch.device),
                 pad_mode="constant",
                 normalized=False,
             )
@@ -136,8 +136,8 @@ class DeepDenoiser(WaveformModel):
             0, nt + shift - 1, shift, device=data.device
         )  # 201 => 0, 100, 200
 
-        std = torch.zeros([nbt, len(t)])
-        mean = torch.zeros([nbt, len(t)])
+        std = torch.zeros([nbt, len(t)], dtype=data.dtype, device=data.device)
+        mean = torch.zeros([nbt, len(t)], dtype=data.dtype, device=data.device)
         for i in range(std.shape[1]):
             std[:, i] = torch.std(
                 data_pad[:, :, i * shift : i * shift + window, :], axis=(1, 2, 3)
@@ -242,7 +242,7 @@ class DeepDenoiser(WaveformModel):
             signal,
             n_fft=60,
             win_length=30,
-            window=torch.hann_window(30),
+            window=torch.hann_window(30).to(batch.device),
             normalized=False,
         )
 

--- a/seisbench/models/gpd.py
+++ b/seisbench/models/gpd.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -107,6 +109,11 @@ class GPD(WaveformModel):
             return self._phases
         else:
             return list(range(self.classes))
+
+    def annotate_batch_pre(
+        self, batch: torch.Tensor, argdict: dict[str, Any]
+    ) -> torch.Tensor:
+        return batch - batch.mean(axis=-1, keepdims=True)
 
     def annotate_window_pre(self, window, argdict):
         # Add a demean step to the preprocessing

--- a/seisbench/models/team.py
+++ b/seisbench/models/team.py
@@ -1,4 +1,5 @@
 import itertools
+from typing import Any
 
 import numpy as np
 import obspy
@@ -45,6 +46,7 @@ class PhaseTEAM(WaveformModel):
             labels=phases,
             sampling_rate=sampling_rate,
             grouping=AlphabeticFullGroupingHelper(max_stations=max_stations),
+            allow_padding=True,
             **kwargs,
         )
 
@@ -139,6 +141,29 @@ class PhaseTEAM(WaveformModel):
         else:
             return torch.sigmoid(y)
 
+    def annotate_batch_pre(
+        self, batch: torch.Tensor, argdict: dict[str, Any]
+    ) -> torch.Tensor:
+        batch = batch - batch.mean(axis=-1, keepdims=True)
+
+        if self.norm == "std":
+            std = batch.std(axis=-1, keepdims=True)
+            batch = batch / std.clip(1e-10)
+        elif self.norm == "peak":
+            peak = batch.abs().max(axis=-1, keepdims=True)[0]
+            batch = batch / (peak + 1e-10)
+
+        # Pad with zeros
+        if batch.shape[1] < self.max_stations:
+            batch = torch.nn.functional.pad(
+                batch,
+                (0, 0, 0, 0, 0, self.max_stations - batch.shape[1]),
+                mode="constant",
+                value=0,
+            )
+
+        return batch
+
     def annotate_window_pre(self, window, argdict):
         # Add a demean and normalize step to the preprocessing
         window = window - np.mean(window, axis=-1, keepdims=True)
@@ -161,6 +186,11 @@ class PhaseTEAM(WaveformModel):
             )
 
         return window
+
+    def annotate_batch_post(
+        self, batch: torch.Tensor, piggyback: Any, argdict: dict[str, Any]
+    ) -> torch.Tensor:
+        return batch.transpose(-1, -2)
 
     def annotate_window_post(self, pred, piggyback=None, argdict=None):
         # Transpose predictions to correct shape

--- a/seisbench/util/__init__.py
+++ b/seisbench/util/__init__.py
@@ -1,4 +1,5 @@
 from .annotations import ClassifyOutput, Detection, DetectionList, Pick, PickList
+from .arraytools import pad_packed_sequence, torch_detrend
 from .auxiliary import in_notebook
 from .decorators import log_lifecycle
 from .file import (

--- a/seisbench/util/arraytools.py
+++ b/seisbench/util/arraytools.py
@@ -1,0 +1,39 @@
+import numpy as np
+import torch
+
+
+def torch_detrend(x: torch.Tensor) -> torch.Tensor:
+    """
+    Detrends a tensor along the last axis using a linear fit.
+
+    :param x: Array to detrend
+    :returns: Detrended array
+    """
+    m = x.mean(dim=-1, keepdim=True)
+    l = torch.linspace(-1, 1, x.shape[-1], device=x.device, dtype=x.dtype)
+    slope = ((x - m) * l).sum(dim=-1, keepdims=True) / (l * l).sum(
+        dim=-1, keepdims=True
+    )
+
+    return x - m - slope * l
+
+
+def pad_packed_sequence(seq: list[np.ndarray]) -> np.ndarray:
+    """
+    Packs a list of arrays into one array by adding a new first dimension and padding where necessary.
+
+    :param seq: List of numpy arrays
+    :return: Combined arrays
+    """
+    max_size = np.array([max([x.shape[i] for x in seq]) for i in range(seq[0].ndim)])
+
+    new_seq = []
+    for i, elem in enumerate(seq):
+        d = max_size - np.array(elem.shape)
+        if (d != 0).any():
+            pad = [(0, d_dim) for d_dim in d]
+            new_seq.append(np.pad(elem, pad, "constant", constant_values=0))
+        else:
+            new_seq.append(elem)
+
+    return np.stack(new_seq, axis=0)

--- a/tests/models/test_annotate_compatibility.py
+++ b/tests/models/test_annotate_compatibility.py
@@ -1,0 +1,201 @@
+"""
+This file checks that the following functions are equivalent:
+- annotate_window_pre and annotate_batch_pre
+- annotate_window_post and annotate_batch_post
+
+As this is essentially a one-of static check, it can be deleted soon.
+When deleting this, all annotate_window_pre and annotate_window_post functions should be deleted too.
+Jannes Münchmeyer - 2024/03
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import seisbench.models as sbm
+
+
+@pytest.mark.parametrize("norm_detrend", [True, False])
+@pytest.mark.parametrize("norm_amp_per_comp", [True, False])
+@pytest.mark.parametrize("norm", ["std", "peak"])
+def test_eqtransformer_pre(norm_detrend, norm_amp_per_comp, norm):
+    model = sbm.EQTransformer(
+        norm_detrend=norm_detrend, norm_amp_per_comp=norm_amp_per_comp, norm=norm
+    )
+    windows = np.random.random((5, 3, 6000))
+
+    batched = model.annotate_batch_pre(torch.tensor(windows), {}).numpy()
+    single = np.stack(
+        [model.annotate_window_pre(window, {}) for window in windows], axis=0
+    )
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+def test_eqtransformer_post():
+    model = sbm.EQTransformer()
+    pred = np.random.rand(5, 3, 6000)
+
+    pred_t = torch.tensor(pred)
+    batched = model.annotate_batch_post(
+        [pred_t[:, 0], pred_t[:, 1], pred_t[:, 2]], {}, {}
+    ).numpy()
+    single = np.stack(
+        [
+            model.annotate_window_post([window[0], window[1], window[2]], {}, {})
+            for window in pred
+        ]
+    )
+
+    assert np.allclose(batched, single, equal_nan=True)
+
+
+@pytest.mark.parametrize("norm_detrend", [True, False])
+@pytest.mark.parametrize("norm_amp_per_comp", [True, False])
+@pytest.mark.parametrize("norm", ["std", "peak"])
+@pytest.mark.parametrize("model", [sbm.PhaseNet, sbm.PhaseNetLight])
+def test_phasenet_pre(norm_detrend, norm_amp_per_comp, norm, model):
+    model = model(
+        norm_detrend=norm_detrend, norm_amp_per_comp=norm_amp_per_comp, norm=norm
+    )
+    windows = np.random.random((5, 3, 3001))
+
+    batched = model.annotate_batch_pre(torch.tensor(windows), {}).numpy()
+    single = np.stack(
+        [model.annotate_window_pre(window, {}) for window in windows], axis=0
+    )
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("model", [sbm.PhaseNet, sbm.PhaseNetLight])
+def test_phasenet_post(model):
+    model = model()
+    pred = np.random.rand(5, 3, 6000)
+
+    pred_t = torch.tensor(pred)
+    batched = model.annotate_batch_post(pred_t, {}, {}).numpy()
+    single = np.stack([model.annotate_window_post(window, {}, {}) for window in pred])
+
+    assert np.allclose(batched, single, equal_nan=True)
+
+
+def test_gpd_pre():
+    model = sbm.GPD()
+    windows = np.random.random((5, 3, 400))
+
+    batched = model.annotate_batch_pre(torch.tensor(windows), {}).numpy()
+    single = np.stack(
+        [model.annotate_window_pre(window, {}) for window in windows], axis=0
+    )
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+def test_gpd_post():
+    model = sbm.GPD()
+    pred = np.random.rand(5, 3)
+
+    pred_t = torch.tensor(pred)
+    batched = model.annotate_batch_post(pred_t, {}, {}).numpy()
+    single = np.stack([model.annotate_window_post(window, {}, {}) for window in pred])
+
+    assert np.allclose(batched, single, equal_nan=True)
+
+
+def test_cred_pre():
+    model = sbm.CRED()
+    windows = np.random.random((5, 3, 3000))
+
+    batched = model.annotate_batch_pre(torch.tensor(windows), {}).numpy()
+    single = np.stack(
+        [model.annotate_window_pre(window, {}) for window in windows], axis=0
+    )
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+def test_cred_post():
+    model = sbm.CRED()
+    windows = np.random.random((5, 3, 3000))
+
+    batched = model.annotate_batch_post(torch.tensor(windows), {}, {}).numpy()
+    single = np.stack(
+        [model.annotate_window_post(window, {}, {}) for window in windows], axis=0
+    )
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+def test_basicphaseae_pre():
+    model = sbm.BasicPhaseAE()
+    windows = np.random.random((5, 3, 600))
+
+    batched = model.annotate_batch_pre(torch.tensor(windows), {}).numpy()
+    single = np.stack(
+        [model.annotate_window_pre(window, {}) for window in windows], axis=0
+    )
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+def test_basicphaseae_post():
+    model = sbm.BasicPhaseAE()
+    pred = np.random.rand(5, 3, 600)
+
+    pred_t = torch.tensor(pred)
+    batched = model.annotate_batch_post(pred_t, {}, {}).numpy()
+    single = np.stack([model.annotate_window_post(window, {}, {}) for window in pred])
+
+    assert np.allclose(batched, single, equal_nan=True)
+
+
+def test_deepdenoiser_pre():
+    model = sbm.DeepDenoiser()
+    windows = np.random.random((5, 3000))
+
+    batched, batched_aux = model.annotate_batch_pre(torch.tensor(windows), {})
+    batched = batched.numpy()
+    batched_aux = batched_aux.numpy()
+    single_full = [model.annotate_window_pre(window, {}) for window in windows]
+    single = np.stack([x[0] for x in single_full])
+    single_aux = np.stack([x[1] for x in single_full])
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+    assert np.allclose(batched_aux, single_aux, rtol=1e-3, atol=1e-3)
+
+
+def test_deepdenoiser_post():
+    model = sbm.DeepDenoiser()
+    x = np.random.random((5, 2, 31, 201))
+    aux = np.random.random((5, 2, 31, 201))
+
+    batched = model.annotate_batch_post(torch.tensor(x), torch.tensor(aux), {})
+    single = [model.annotate_window_post(wx, waux, {}) for wx, waux in zip(x, aux)]
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("max_stations", [4, 10])  # Same as shape or bigger than shape
+@pytest.mark.parametrize("norm", ["std", "peak"])
+def test_phaseteam_pre(max_stations, norm):
+    model = sbm.PhaseTEAM(norm=norm, max_stations=max_stations)
+    windows = np.random.rand(5, 4, 3, 3001)
+
+    batched = model.annotate_batch_pre(torch.tensor(windows), {}).numpy()
+    single = np.stack(
+        [model.annotate_window_pre(window, {}) for window in windows], axis=0
+    )
+
+    assert np.allclose(batched, single, rtol=1e-3, atol=1e-3)
+
+
+def test_phaseteam_post():
+    model = sbm.PhaseTEAM()
+    pred = np.random.rand(5, 3, 3001)
+
+    pred_t = torch.tensor(pred)
+    batched = model.annotate_batch_post(pred_t, {}, {}).numpy()
+    single = np.stack([model.annotate_window_post(window, {}, {}) for window in pred])
+
+    assert np.allclose(batched, single, equal_nan=True)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -69,16 +69,6 @@ def test_get_component_mapping():
     assert dummy._get_component_mapping("ZNE", "ZNEH") == [0, 1, 2]
 
 
-def test_pad_packed_sequence():
-    seq = [np.ones((5, 1)), np.ones((6, 3)), np.ones((1, 2)), np.ones((7, 2))]
-
-    packed = seisbench.data.WaveformDataset._pad_packed_sequence(seq)
-
-    assert packed.shape == (4, 7, 3)
-    assert np.sum(packed == 1) == sum(x.size for x in seq)
-    assert np.sum(packed == 0) == packed.size - sum(x.size for x in seq)
-
-
 def test_preload():
     dummy = seisbench.data.DummyDataset(cache="trace")
     assert len(dummy._waveform_cache) == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -894,42 +894,34 @@ def test_default_labels():
     assert model.labels == [0, 1, 2]
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_annotate_cred(parallelism):
+def test_annotate_cred():
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     model = seisbench.models.CRED(
         sampling_rate=400
     )  # Higher sampling rate ensures trace is long enough
     stream = obspy.read()
 
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
     assert len(annotations) > 0
     output = model.classify(
-        stream, parallelism=parallelism
+        stream
     )  # Ensures classify succeeds even though labels are unknown
     assert isinstance(output, sbu.ClassifyOutput)
     assert isinstance(output.detections, sbu.DetectionList)
     assert output.creator == model.name
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_annotate_eqtransformer(parallelism):
+def test_annotate_eqtransformer():
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     model = seisbench.models.EQTransformer(
         sampling_rate=400
     )  # Higher sampling rate ensures trace is long enough
     stream = obspy.read()
 
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
     assert len(annotations) > 0
     output = model.classify(
-        stream, parallelism=parallelism
+        stream
     )  # Ensures classify succeeds even though labels are unknown
     assert isinstance(output, sbu.ClassifyOutput)
     assert isinstance(output.picks, sbu.PickList)
@@ -938,15 +930,13 @@ def test_annotate_eqtransformer(parallelism):
 
 
 @pytest.mark.parametrize(
-    "parallelism,model",
+    "model",
     [
-        (None, "phasenet"),
-        (1, "phasenet"),
-        (None, "eqtransformer"),
-        (1, "eqtransformer"),
+        "phasenet",
+        "eqtransformer",
     ],
 )
-def test_annotate_pickblue(parallelism, model):
+def test_annotate_pickblue(model):
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     with patch(
         "seisbench.models.SeisBenchModel._check_version_requirement"
@@ -956,91 +946,75 @@ def test_annotate_pickblue(parallelism, model):
     model.sampling_rate = 400  # Higher sampling rate ensures trace is long enough
 
     stream = obspy.read("./tests/examples/OBS*")
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
     assert len(annotations) == 3
     model.classify(
-        stream, parallelism=parallelism
+        stream,
     )  # Ensures classify succeeds even though labels are unknown
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_annotate_gpd(parallelism):
+def test_annotate_gpd():
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     model = seisbench.models.GPD(
         sampling_rate=100
     )  # Higher sampling rate ensures trace is long enough
     stream = obspy.read()
 
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
     assert len(annotations) > 0
     output = model.classify(
-        stream, parallelism=parallelism
+        stream
     )  # Ensures classify succeeds even though labels are unknown
     assert isinstance(output, sbu.ClassifyOutput)
     assert isinstance(output.picks, sbu.PickList)
     assert output.creator == model.name
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_annotate_phasenetlight(parallelism):
+def test_annotate_phasenetlight():
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     model = seisbench.models.PhaseNetLight(
         sampling_rate=400
     )  # Higher sampling rate ensures trace is long enough
     stream = obspy.read()
 
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
     assert len(annotations) > 0
     output = model.classify(
-        stream, parallelism=parallelism
+        stream
     )  # Ensures classify succeeds even though labels are unknown
     assert isinstance(output, sbu.ClassifyOutput)
     assert isinstance(output.picks, sbu.PickList)
     assert output.creator == model.name
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_annotate_phasenet(parallelism):
+def test_annotate_phasenet():
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     model = seisbench.models.PhaseNet(
         sampling_rate=400
     )  # Higher sampling rate ensures trace is long enough
     stream = obspy.read()
 
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
     assert len(annotations) > 0
     output = model.classify(
-        stream, parallelism=parallelism
+        stream
     )  # Ensures classify succeeds even though labels are unknown
     assert isinstance(output, sbu.ClassifyOutput)
     assert isinstance(output.picks, sbu.PickList)
     assert output.creator == model.name
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_annotate_basicphaseae(parallelism):
+def test_annotate_basicphaseae():
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     model = seisbench.models.BasicPhaseAE(
         sampling_rate=400
     )  # Higher sampling rate ensures trace is long enough
     stream = obspy.read()
 
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
     assert len(annotations) > 0
     output = model.classify(
-        stream, parallelism=parallelism
+        stream
     )  # Ensures classify succeeds even though labels are unknown
     assert isinstance(output, sbu.ClassifyOutput)
     assert isinstance(output.picks, sbu.PickList)
@@ -1072,15 +1046,11 @@ def test_deep_denoiser():
     seisbench.models.DeepDenoiser()
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_annotate_deep_denoiser(parallelism):
+def test_annotate_deep_denoiser():
     stream = obspy.read()
 
     model = seisbench.models.DeepDenoiser()
-    annotations = model.annotate(stream, parallelism=parallelism)
+    annotations = model.annotate(stream)
 
     assert len(annotations) == 3
     for i in range(3):
@@ -1352,51 +1322,6 @@ def test_save_load_model_updated_after_construction_inheritence_compatible(tmp_p
     model_loaded = model_orig.load(tmp_path / "gpd_changed")
 
     assert model_orig.component_order == model_loaded.component_order
-
-
-def test_check_parallelism_annotate(caplog):
-    t0 = UTCDateTime(0)
-    stats = {
-        "network": "SB",
-        "station": "TEST",
-        "channel": "HHZ",
-        "sampling_rate": 100,
-        "starttime": t0,
-    }
-
-    trace0 = obspy.Trace(np.zeros(1000), stats)
-    trace1 = obspy.Trace(np.ones(1000), stats)
-    stream_small = obspy.Stream([trace0, trace1])
-
-    trace0 = obspy.Trace(np.zeros(int(3e7)), stats)
-    trace1 = obspy.Trace(np.zeros(int(3e7)), stats)
-    stream_large = obspy.Stream([trace0, trace1])
-
-    with caplog.at_level(logging.WARNING):
-        seisbench.models.WaveformModel._check_parallelism_annotate(
-            stream_small, parallelism=None
-        )
-    assert "Consider activating parallelisation. " not in caplog.text
-
-    with caplog.at_level(logging.WARNING):
-        seisbench.models.WaveformModel._check_parallelism_annotate(
-            stream_large, parallelism=None
-        )
-    assert "Consider activating parallelisation. " in caplog.text
-
-    caplog.clear()
-
-    with caplog.at_level(logging.WARNING):
-        seisbench.models.WaveformModel._check_parallelism_annotate(
-            stream_large, parallelism=1
-        )
-    assert "Consider using the sequential asyncio implementation. " not in caplog.text
-
-    with caplog.at_level(logging.WARNING):
-        seisbench.models.WaveformModel._check_parallelism_annotate(
-            stream_small, parallelism=1
-        )
-    assert "Consider using the sequential asyncio implementation. " in caplog.text
 
 
 def test_get_versions_from_files():
@@ -2014,9 +1939,8 @@ def test_eqtransformer_forward():
 
 def test_cred_forward():
     model = seisbench.models.CRED()
-    x = np.random.rand(3, 3000)
-    x = np.expand_dims(model.waveforms_to_spectrogram(x), 0).astype(np.float32)
-    x = torch.from_numpy(x)
+    x = np.random.rand(2, 3, 3000)
+    x = model.waveforms_to_spectrogram(torch.tensor(x, dtype=torch.float32))
 
     with torch.no_grad():
         pred = model(x).numpy()
@@ -2488,11 +2412,7 @@ def test_annotate_empty():
     assert len(ann) == 0
 
 
-@pytest.mark.parametrize(
-    "parallelism",
-    [None, 1],
-)
-def test_overlap_mismatching_records_empty(parallelism):
+def test_overlap_mismatching_records_empty():
     model = seisbench.models.PhaseNet()
 
     header = {
@@ -2506,6 +2426,20 @@ def test_overlap_mismatching_records_empty(parallelism):
     trace1 = obspy.Trace(np.ones(10000), header=header)
     trace2 = obspy.Trace(np.zeros(10000), header=header)
 
-    ann = model.annotate(obspy.Stream([trace1, trace2]), parallelism=parallelism)
+    ann = model.annotate(obspy.Stream([trace1, trace2]))
 
     assert len(ann) == 0
+
+
+def test_predict_buffer_padding():
+    # Note: Normally, for PhaseNet we don't want the model to do padding.
+    model = seisbench.models.PhaseNet()
+
+    buffer = [np.random.rand(i, 3001) for i in range(1, 4)]
+
+    model.allow_padding = False
+    with pytest.raises(ValueError):
+        model._predict_buffer(buffer, {})
+
+    model.allow_padding = True
+    model._predict_buffer(buffer, {})


### PR DESCRIPTION
Pre- and postprocessing in the annotate function was so far done per window and in numpy. This PR changes the processing to a batched mode running on PyTorch. This also ensures that all processing can happen on the GPU if available. In addition, this now allows to wrap the three processing steps in a thread, allowing to release the GIL during the heavy numeric operations. Overall, this will reduce run times, in particular, on GPU.

As this change improves the efficiency of the asyncio implementation, it removes the (suboptimal) process implementation completely.

To ensure compatibility with the previous implementation, a suite of tests has been added and the former `annotate_window_pre`/`annotate_window_post` functions are retained. These functions and tests should be removed in a future PR.

Additional small changes:
- added minimal benchmark for annotate performance (results coming in a bit)
- increased default batch size from 64 to 256
- refactored some functions in seisbench.util

Closes #269 