### PR TITLE
Pin numpy version to avoid CI crashes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
-    "numpy>=1.21.6",
+    # < 2 pinning is required for obspy (https://github.com/obspy/obspy/issues/3484)
+    # remove once fixed with obspy 1.5
+    "numpy>=1.21.6, <2.0",
     "pandas>=1.1",
     "h5py>=3.1",
     "obspy>=1.3.1",


### PR DESCRIPTION
Caused by obspy dependency problem (https://github.com/obspy/obspy/issues/3484). Will be fixed in obspy v1.5. The version pinning should be removed then.