### PR TITLE
DOC: Fix two typos 

### DIFF
--- a/docs/pages/benchmark_datasets.rst
+++ b/docs/pages/benchmark_datasets.rst
@@ -143,7 +143,7 @@ INSTANCE
    :align:   center
 
 
-The INSTANCE benchmark dataset is a dataset of signals comiled by the Istituto Nazionale di Geofisica e Vulcanologia
+The INSTANCE benchmark dataset is a dataset of signals compiled by the Istituto Nazionale di Geofisica e Vulcanologia
 (INGV). Containing ~1.2 million 3C waveform traces, which record ~50,000 earthquakes and include ~130,000 noise traces.
 Magnitude scale of events ranges from 0 - 6.5.
 The dataset is split for ease of use into Noise examples :py:class:`~seisbench.data.instance.InstanceNoise`,

--- a/docs/pages/data_format.rst
+++ b/docs/pages/data_format.rst
@@ -11,7 +11,7 @@ These files need to reside in the same folder and need to be named *metadata.csv
 
 SeisBench implements a standard reader and a standard writer for this data format.
 The standard reader is the class :py:class:`~seisbench.data.base.WaveformDataset`.
-The standard writer is the class :py:class:`~seisbench.data.base.WaveformDataWriter`
+The standard writer is the class :py:class:`~seisbench.data.base.WaveformDataWriter`.
 Please consult their documentations for details on reading and writing the format.
 Derived from the :py:class:`~seisbench.data.base.WaveformDataset`,
 SeisBench offers a range of :doc:`benchmark datasets<benchmark_datasets>` in SeisBench format.


### PR DESCRIPTION
This PR contains just two typo fixes in the documentation.