### PR TITLE
Add PhaseNetWC model through filter_factor option

### DIFF
--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -489,6 +489,7 @@ class SeisBenchModel(nn.Module):
         model_weights = torch.load(f"{path_pt}")
 
         model_args = weights_metadata.get("model_args", {})
+        cls._check_version_requirement(weights_metadata)
         model = cls(**model_args)
         model._weights_metadata = weights_metadata
         model._parse_metadata()
@@ -618,17 +619,13 @@ class SeisBenchModel(nn.Module):
         self._weights_docstring = self._weights_metadata.get("docstring", "")
         self._weights_version = self._weights_metadata.get("version", "1")
 
-        # Check version requirement
-        self._check_version_requirement()
-
         # Parse default args - Config default_args supersede constructor args
         default_args = self._weights_metadata.get("default_args", {})
         self.default_args.update(default_args)
 
-    def _check_version_requirement(self):
-        seisbench_requirement = self._weights_metadata.get(
-            "seisbench_requirement", None
-        )
+    @staticmethod
+    def _check_version_requirement(weights_metadata):
+        seisbench_requirement = weights_metadata.get("seisbench_requirement", None)
         if seisbench_requirement is not None:
             if version.parse(seisbench_requirement) > version.parse(
                 seisbench.__version__

--- a/seisbench/models/phasenet.py
+++ b/seisbench/models/phasenet.py
@@ -15,6 +15,9 @@ from .base import Conv1dSame, WaveformModel, _cache_migration_v0_v3
 class PhaseNet(WaveformModel):
     """
     .. document_args:: seisbench.models PhaseNet
+
+    :param filter_factor: Increase the number of filters used in each layer by this factor compared to the original
+                          PhaseNet. Based on PhaseNetWC proposed by Naoi et al. (2024)
     """
 
     _annotate_args = WaveformModel._annotate_args.copy()
@@ -49,6 +52,7 @@ class PhaseNet(WaveformModel):
         phases="NPS",
         sampling_rate=100,
         norm="std",
+        filter_factor: int = 1,
         **kwargs,
     ):
         citation = (
@@ -79,6 +83,7 @@ class PhaseNet(WaveformModel):
         self.in_channels = in_channels
         self.classes = classes
         self.norm = norm
+        self.filter_factor = filter_factor
         self.depth = 5
         self.kernel_size = 7
         self.stride = 4
@@ -86,16 +91,19 @@ class PhaseNet(WaveformModel):
         self.activation = torch.relu
 
         self.inc = nn.Conv1d(
-            self.in_channels, self.filters_root, self.kernel_size, padding="same"
+            self.in_channels,
+            self.filters_root * filter_factor,
+            self.kernel_size,
+            padding="same",
         )
-        self.in_bn = nn.BatchNorm1d(8, eps=1e-3)
+        self.in_bn = nn.BatchNorm1d(self.filters_root * filter_factor, eps=1e-3)
 
         self.down_branch = nn.ModuleList()
         self.up_branch = nn.ModuleList()
 
-        last_filters = self.filters_root
+        last_filters = self.filters_root * filter_factor
         for i in range(self.depth):
-            filters = int(2**i * self.filters_root)
+            filters = int(2**i * self.filters_root) * filter_factor
             conv_same = nn.Conv1d(
                 last_filters, filters, self.kernel_size, padding="same", bias=False
             )
@@ -122,7 +130,7 @@ class PhaseNet(WaveformModel):
             self.down_branch.append(nn.ModuleList([conv_same, bn1, conv_down, bn2]))
 
         for i in range(self.depth - 1):
-            filters = int(2 ** (3 - i) * self.filters_root)
+            filters = int(2 ** (3 - i) * self.filters_root) * filter_factor
             conv_up = nn.ConvTranspose1d(
                 last_filters, filters, self.kernel_size, self.stride, bias=False
             )

--- a/seisbench/models/phasenet.py
+++ b/seisbench/models/phasenet.py
@@ -323,6 +323,7 @@ class PhaseNet(WaveformModel):
             weights_metadata = {}
         model_args = weights_metadata.get("model_args", {})
         model_args["in_channels"] = 4
+        cls._check_version_requirement(weights_metadata)
         model = cls(**model_args)
 
         model._weights_metadata = weights_metadata

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -987,10 +987,12 @@ def test_annotate_phasenetlight():
     assert output.creator == model.name
 
 
-def test_annotate_phasenet():
+@pytest.mark.parametrize("filter_factor", [1, 2])
+def test_annotate_phasenet(filter_factor):
     # Tests that the annotate/classify functions run without crashes and annotate produces an output
     model = seisbench.models.PhaseNet(
-        sampling_rate=400
+        sampling_rate=400,
+        filter_factor=filter_factor,
     )  # Higher sampling rate ensures trace is long enough
     stream = obspy.read()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -853,19 +853,19 @@ def test_parse_seisbench_requirements():
 
     with patch("seisbench.__version__", "1.2.3"):
         # Minimum version
-        model._weights_metadata = {"seisbench_requirement": seisbench.__version__}
-        model._parse_metadata()
+        weights_metadata = {"seisbench_requirement": seisbench.__version__}
+        model._check_version_requirement(weights_metadata)
 
         # Newer version
-        model._weights_metadata = {"seisbench_requirement": seisbench.__version__ + "1"}
+        weights_metadata = {"seisbench_requirement": seisbench.__version__ + "1"}
         with pytest.raises(ValueError):
-            model._parse_metadata()
+            model._check_version_requirement(weights_metadata)
 
         # Older version
         version = seisbench.__version__
         version = version[:-1] + chr(ord(version[-1]) - 1)
-        model._weights_metadata = {"seisbench_requirement": version}
-        model._parse_metadata()
+        weights_metadata = {"seisbench_requirement": version}
+        model._check_version_requirement(weights_metadata)
 
 
 def test_parse_default_args():


### PR DESCRIPTION
Add the option to increase the number of filters used in PhaseNet by a constant factor. This option has been proposed by Naoi et al. (2024), see https://doi.org/10.1186/s40623-024-02091-8. The `jma_wc` weight is already available in the SeisBench repository, but sets a version requirement to the future 0.9 release as it relies on this PR. The regular JMA weights are already usable though.