### PR TITLE
Add Python 3.13 to the test matrix

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest --durations=10 -p no:faulthandler tests/
+          pytest --durations=10 tests/

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v3
@@ -54,4 +54,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest tests/
+          pytest --durations=10 tests/

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest --durations=10 tests/
+          pytest --durations=10 -p no:faulthandler tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ include = ["seisbench*"]
 
 [project.optional-dependencies]
 development = ["flake8", "black", "isort", "pre-commit"]
-tests = ["pytest", "pytest-asyncio"]
+tests = ["pytest"]
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
-    # < 2 pinning is required for obspy (https://github.com/obspy/obspy/issues/3484)
-    # remove once fixed with obspy 1.5
-    "numpy>=1.21.6, <2.0",
+    "numpy>=1.21.6",
     "pandas>=1.1",
     "h5py>=3.1",
     "obspy>=1.3.1",


### PR DESCRIPTION
- follows Python version support schedule (https://devguide.python.org/versions/)
- for debugging purpose, adds outputs of the 10 slowest tests from each run
- removes obsolete dependency on `pytest-asyncio`
- removes version pinning `numpy<2` because obspy is now compatible with numpy 2