### PR TITLE
Enable specifying overlaps in annotate as fractions instead (Closes #353)

### DIFF
--- a/seisbench/models/phasenet.py
+++ b/seisbench/models/phasenet.py
@@ -476,6 +476,9 @@ class VariableLengthPhaseNet(PhaseNet):
     .. document_args:: seisbench.models VariableLengthPhaseNet
     """
 
+    _annotate_args = PhaseNet._annotate_args.copy()
+    _annotate_args["overlap"] = (_annotate_args["overlap"][0], 0.5)
+
     def __init__(
         self,
         in_samples=600,
@@ -501,7 +504,6 @@ class VariableLengthPhaseNet(PhaseNet):
             citation=citation,
             in_samples=in_samples,
             output_type="array",
-            default_args={"overlap": in_samples // 2},
             pred_sample=(0, in_samples),
             labels=phases,
             sampling_rate=sampling_rate,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1008,6 +1008,20 @@ def test_annotate_phasenet(filter_factor):
     assert output.creator == model.name
 
 
+def test_annotate_overlap():
+    # Tests that the annotate function works the same with fractional and sample overlap
+    model = seisbench.models.PhaseNet(
+        sampling_rate=400,
+    )  # Higher sampling rate ensures trace is long enough
+    stream = obspy.read()
+
+    annotations1 = model.annotate(stream, overlap=0.5)
+    annotations2 = model.annotate(stream, overlap=int(0.5 * model.in_samples))
+    assert len(annotations1) == len(annotations2)
+    for t1, t2 in zip(annotations1, annotations2):
+        assert (t1.data == t2.data).all()
+
+
 @pytest.mark.parametrize("output_activation", ["sigmoid", "softmax"])
 @pytest.mark.parametrize("norm", ["std", "peak"])
 @pytest.mark.parametrize("in_samples", [1337, 3001, 6000])


### PR DESCRIPTION
Also cleans up the overlap specification for VariableLengthPhaseNet