### PR TITLE
Update Python requirements to >=3.10 and add support for Python 3.14

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/seisbench/seisbench/main_push.yml?branch=main)](https://github.com/seisbench/seisbench)
 [![Read the Docs](https://img.shields.io/readthedocs/seisbench)](https://seisbench.readthedocs.io/en/latest/)
 [![PyPI](https://img.shields.io/pypi/v/seisbench)](https://pypi.org/project/seisbench/)
-[![Python 3.9](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/release/python-390/)
+[![Python 3.10](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5568813.svg)](https://doi.org/10.5281/zenodo.5568813)
 
 The Seismology Benchmark collection (*SeisBench*) is an open-source python toolbox for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "The seismological machine learning benchmark collection"
 readme = "README.md"
 license = { text = "GPLv3" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Jack Woolam", email = "jack.woollam@kit.edu" },
     { name = "Jannes Münchmeyer", email = "munchmej@gfz-potsdam.de" },


### PR DESCRIPTION
Also changes the test matrix accordingly. Changes in accordance with the Python support schedule (https://devguide.python.org/versions/)

As the official 3.14 release date is only 2025-10-07, the PR can not be merged before (and CI will fail until then).