### PR TITLE
Introduce `AbstractBenchmarkDataset` class

### DIFF
--- a/seisbench/data/__init__.py
+++ b/seisbench/data/__init__.py
@@ -3,6 +3,8 @@ from .aq2009 import (
     AQ2009Counts,
 )
 from .base import (
+    AbstractBenchmarkDataset,
+    WaveformBenchmarkDataset,
     BenchmarkDataset,
     Bucketer,
     GeometricBucketer,
@@ -55,7 +57,9 @@ from .txed import TXED
 from .vcseis import VCSEIS
 
 __all__ = [
+    "AbstractBenchmarkDataset",
     "BenchmarkDataset",
+    "WaveformBenchmarkDataset",
     "Bucketer",
     "GeometricBucketer",
     "MultiWaveformDataset",

--- a/seisbench/data/aq2009.py
+++ b/seisbench/data/aq2009.py
@@ -1,7 +1,7 @@
-from seisbench.data.base import BenchmarkDataset
+from seisbench.data.base import WaveformBenchmarkDataset
 
 
-class AQ2009Counts(BenchmarkDataset):
+class AQ2009Counts(WaveformBenchmarkDataset):
     """
     AQ2009 aftershocks digital units dataset from Bagagli et al. (2023)
 
@@ -26,7 +26,7 @@ class AQ2009Counts(BenchmarkDataset):
         pass
 
 
-class AQ2009GM(BenchmarkDataset):
+class AQ2009GM(WaveformBenchmarkDataset):
     """
     AQ2009 aftershocks ground motion dataset from Bagagli et al. (2023)
 

--- a/seisbench/data/ceed.py
+++ b/seisbench/data/ceed.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 import seisbench
 
-from .base import BenchmarkDataset, WaveformDataWriter
+from .base import WaveformBenchmarkDataset, WaveformDataWriter
 
 try:
     from huggingface_hub import hf_hub_download
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
     hf_hub_download = None
 
 
-class CEED(BenchmarkDataset):
+class CEED(WaveformBenchmarkDataset):
     """
     The CEED dataset for California from Zhu et al. (2025)
     """

--- a/seisbench/data/crew.py
+++ b/seisbench/data/crew.py
@@ -1,7 +1,7 @@
-from seisbench.data.base import BenchmarkDataset
+from seisbench.data.base import WaveformBenchmarkDataset
 
 
-class CREW(BenchmarkDataset):
+class CREW(WaveformBenchmarkDataset):
     """
     Curated Regional Earthquake Waveforms (CREW dataset)
 

--- a/seisbench/data/cwa.py
+++ b/seisbench/data/cwa.py
@@ -7,7 +7,7 @@ import pandas as pd
 import seisbench
 import seisbench.util
 
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 try:
     from huggingface_hub import hf_hub_download
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
     hf_hub_download = None
 
 
-class CWABase(BenchmarkDataset, ABC):
+class CWABase(WaveformBenchmarkDataset, ABC):
     """
     An abstract class for downloading datasets.
     The CWA dataset comprises data from two seismographic networks: CWASN and TSMIP.

--- a/seisbench/data/dummy.py
+++ b/seisbench/data/dummy.py
@@ -6,10 +6,10 @@ from obspy.clients.fdsn import Client
 import seisbench
 import seisbench.util
 
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class DummyDataset(BenchmarkDataset):
+class DummyDataset(WaveformBenchmarkDataset):
     """
     A dummy dataset visualizing the implementation of custom datasets
     """
@@ -101,7 +101,7 @@ class DummyDataset(BenchmarkDataset):
             writer.add_trace(row, waveform)
 
 
-class ChunkedDummyDataset(BenchmarkDataset):
+class ChunkedDummyDataset(WaveformBenchmarkDataset):
     """
     A chunked dummy dataset visualizing the implementation of custom datasets with chunking
     """

--- a/seisbench/data/ethz.py
+++ b/seisbench/data/ethz.py
@@ -12,7 +12,7 @@ from obspy.geodetics import gps2dist_azimuth
 from tqdm import tqdm
 
 import seisbench
-from seisbench.data.base import BenchmarkDataset
+from seisbench.data.base import WaveformBenchmarkDataset
 from seisbench.util.trace_ops import (
     rotate_stream_to_zne,
     stream_to_array,
@@ -21,7 +21,7 @@ from seisbench.util.trace_ops import (
 )
 
 
-class ETHZ(BenchmarkDataset):
+class ETHZ(WaveformBenchmarkDataset):
     """
     Regional benchmark dataset of publicly available waveform data & corresponding
     metadata in Swiss Seismological Service (SED) archive. Contains data from

--- a/seisbench/data/geofon.py
+++ b/seisbench/data/geofon.py
@@ -15,10 +15,10 @@ from seisbench.util.trace_ops import (
     trace_has_spikes,
 )
 
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class GEOFON(BenchmarkDataset):
+class GEOFON(WaveformBenchmarkDataset):
     """
     GEOFON dataset consisting of both regional and teleseismic picks. Mostly contains P arrivals,
     but a few S arrivals are annotated as well. Contains data from 2010-2013. The dataset will be

--- a/seisbench/data/instance.py
+++ b/seisbench/data/instance.py
@@ -8,10 +8,10 @@ import pandas as pd
 import seisbench
 import seisbench.util
 
-from .base import BenchmarkDataset, MultiWaveformDataset
+from .base import WaveformBenchmarkDataset, MultiWaveformDataset
 
 
-class InstanceTypeDataset(BenchmarkDataset, ABC):
+class InstanceTypeDataset(WaveformBenchmarkDataset, ABC):
     """
     Abstract class for all datasets in the INSTANCE structure.
     Provides a helper function for downloading the datasets to avoid code duplication.

--- a/seisbench/data/iquique.py
+++ b/seisbench/data/iquique.py
@@ -1,9 +1,9 @@
 import seisbench
 
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class Iquique(BenchmarkDataset):
+class Iquique(WaveformBenchmarkDataset):
     """
     Iquique Benchmark Dataset of local events used for training in Woollam (2019)
     study (see citation).

--- a/seisbench/data/isc_ehb.py
+++ b/seisbench/data/isc_ehb.py
@@ -1,7 +1,7 @@
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class ISC_EHB_DepthPhases(BenchmarkDataset):
+class ISC_EHB_DepthPhases(WaveformBenchmarkDataset):
     """
     Dataset of depth phase picks from the
     `ISC-EHB bulletin <http://www.isc.ac.uk/isc-ehb/>`_.

--- a/seisbench/data/lendb.py
+++ b/seisbench/data/lendb.py
@@ -6,10 +6,10 @@ from obspy import UTCDateTime
 import seisbench
 import seisbench.util
 
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class LenDB(BenchmarkDataset):
+class LenDB(WaveformBenchmarkDataset):
     """
     Len-DB dataset from Magrini et al.
     """

--- a/seisbench/data/lfe_stacks.py
+++ b/seisbench/data/lfe_stacks.py
@@ -1,7 +1,7 @@
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class LFEStacksCascadiaBostock2015(BenchmarkDataset):
+class LFEStacksCascadiaBostock2015(WaveformBenchmarkDataset):
     """
     Low-frequency earthquake stacks underneath Vancouver Island, Cascadia, Canada/USA based on the catalog by
     Bostock et al (2015). Compiled to SeisBench format by Münchmeyer et al (2024).
@@ -26,7 +26,7 @@ class LFEStacksCascadiaBostock2015(BenchmarkDataset):
         pass
 
 
-class LFEStacksMexicoFrank2014(BenchmarkDataset):
+class LFEStacksMexicoFrank2014(WaveformBenchmarkDataset):
     """
     Low-frequency earthquake stacks underneath Guerrero, Mexico based on the catalog by
     Frank et al (2014). Compiled to SeisBench format by Münchmeyer et al (2024).
@@ -51,7 +51,7 @@ class LFEStacksMexicoFrank2014(BenchmarkDataset):
         pass
 
 
-class LFEStacksSanAndreasShelly2017(BenchmarkDataset):
+class LFEStacksSanAndreasShelly2017(WaveformBenchmarkDataset):
     """
     Low-frequency earthquake stacks on the San Andreas Fault, California, USA based on the catalog by
     Shelly (2014). Compiled to SeisBench format by Münchmeyer et al (2024).

--- a/seisbench/data/neic.py
+++ b/seisbench/data/neic.py
@@ -8,13 +8,13 @@ import numpy as np
 import seisbench
 import seisbench.util
 
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 # Conversion from earth radius
 DEG2KM = 2 * np.pi * 6371 / 360
 
 
-class NEIC(BenchmarkDataset):
+class NEIC(WaveformBenchmarkDataset):
     """
     NEIC dataset from Yeck and Patton
     """
@@ -212,7 +212,7 @@ class NEIC(BenchmarkDataset):
             shutil.rmtree(path_original)
 
 
-class MLAAPDE(BenchmarkDataset):
+class MLAAPDE(WaveformBenchmarkDataset):
     """
     MLAAPDE dataset from Cole et al. (2023)
 

--- a/seisbench/data/obs.py
+++ b/seisbench/data/obs.py
@@ -1,8 +1,8 @@
 import seisbench.util
-from seisbench.data.base import BenchmarkDataset
+from seisbench.data.base import WaveformBenchmarkDataset
 
 
-class OBS(BenchmarkDataset):
+class OBS(WaveformBenchmarkDataset):
     """
     OBS Benchmark Dataset of local events
 

--- a/seisbench/data/obst2024.py
+++ b/seisbench/data/obst2024.py
@@ -1,7 +1,7 @@
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class OBST2024(BenchmarkDataset):
+class OBST2024(WaveformBenchmarkDataset):
     """
     The OBS dataset from Niksejel & Zhang (2024)
     """

--- a/seisbench/data/pisdl.py
+++ b/seisbench/data/pisdl.py
@@ -1,7 +1,7 @@
-from seisbench.data.base import BenchmarkDataset
+from seisbench.data.base import WaveformBenchmarkDataset
 
 
-class PiSDL(BenchmarkDataset):
+class PiSDL(WaveformBenchmarkDataset):
     """
     A dataset for induced seismicity from different regions in Canada, Switzerland,
     Germany, and France. Induced seismic events are caused by hydraulic-fracturing

--- a/seisbench/data/pnw.py
+++ b/seisbench/data/pnw.py
@@ -1,7 +1,7 @@
-from seisbench.data.base import BenchmarkDataset
+from seisbench.data.base import WaveformBenchmarkDataset
 
 
-class PNW(BenchmarkDataset):
+class PNW(WaveformBenchmarkDataset):
     """
     PNW ComCat dataset from Ni et al. (2023)
 
@@ -24,7 +24,7 @@ class PNW(BenchmarkDataset):
         pass
 
 
-class PNWExotic(BenchmarkDataset):
+class PNWExotic(WaveformBenchmarkDataset):
     """
     PNW Exotic dataset from Ni et al. (2023)
 
@@ -47,7 +47,7 @@ class PNWExotic(BenchmarkDataset):
         pass
 
 
-class PNWAccelerometers(BenchmarkDataset):
+class PNWAccelerometers(WaveformBenchmarkDataset):
     """
     PNW Accelerometers dataset from Ni et al. (2023)
 
@@ -70,7 +70,7 @@ class PNWAccelerometers(BenchmarkDataset):
         pass
 
 
-class PNWNoise(BenchmarkDataset):
+class PNWNoise(WaveformBenchmarkDataset):
     """
     PNW Noise dataset from Ni et al. (2023)
 

--- a/seisbench/data/scedc.py
+++ b/seisbench/data/scedc.py
@@ -7,10 +7,10 @@ import numpy as np
 import seisbench
 import seisbench.util
 
-from .base import BenchmarkDataset
+from .base import WaveformBenchmarkDataset
 
 
-class SCEDC(BenchmarkDataset):
+class SCEDC(WaveformBenchmarkDataset):
     """
     SCEDC waveform archive (2000-2020).
 
@@ -38,7 +38,7 @@ class SCEDC(BenchmarkDataset):
 
 # TODO: Check with Zach Ross if this dataset really only differs from Ross2018JGRPick through the class rebalancing.
 #       If so, it this should be stated in the SeisBench documentation and probably also be reflected in the naming.
-class Ross2018JGRFM(BenchmarkDataset):
+class Ross2018JGRFM(WaveformBenchmarkDataset):
     """
     First motion polarity dataset belonging to the publication:
     Ross, Z. E., Meier, M.‐A., & Hauksson, E. (2018). P wave arrival picking and first‐motion polarity determination
@@ -194,7 +194,7 @@ class Ross2018JGRFM(BenchmarkDataset):
             shutil.rmtree(path_original)
 
 
-class Ross2018JGRPick(BenchmarkDataset):
+class Ross2018JGRPick(WaveformBenchmarkDataset):
     """
     Pick dataset belonging to the publication:
     Ross, Z. E., Meier, M.‐A., & Hauksson, E. (2018). P wave arrival picking and first‐motion polarity determination
@@ -350,7 +350,7 @@ class Ross2018JGRPick(BenchmarkDataset):
             shutil.rmtree(path_original)
 
 
-class Ross2018GPD(BenchmarkDataset):
+class Ross2018GPD(WaveformBenchmarkDataset):
     """
     Pick dataset belonging to the publication:
     Zachary E. Ross, Men‐Andrin Meier, Egill Hauksson, Thomas H. Heaton;
@@ -456,7 +456,7 @@ class Ross2018GPD(BenchmarkDataset):
 
 
 # TODO: Write Men-Andrin Meier regarding zero metadata columns, time format, split format
-class Meier2019JGR(BenchmarkDataset):
+class Meier2019JGR(WaveformBenchmarkDataset):
     """
     Southern californian part of the dataset from Meier et al. (2019)
     Note that due to the missing Japanese data,

--- a/seisbench/data/stead.py
+++ b/seisbench/data/stead.py
@@ -7,10 +7,10 @@ import pandas as pd
 import seisbench
 import seisbench.util
 
-from .base import BenchmarkDataset, WaveformDataWriter
+from .base import WaveformBenchmarkDataset, WaveformDataWriter
 
 
-class STEAD(BenchmarkDataset):
+class STEAD(WaveformBenchmarkDataset):
     """
     STEAD dataset from Mousavi et al.
 

--- a/seisbench/data/txed.py
+++ b/seisbench/data/txed.py
@@ -5,10 +5,10 @@ import h5py
 
 import seisbench
 
-from .base import BenchmarkDataset, WaveformDataWriter
+from .base import WaveformBenchmarkDataset, WaveformDataWriter
 
 
-class TXED(BenchmarkDataset):
+class TXED(WaveformBenchmarkDataset):
     """
     TEXD dataset from Chen et al.
 

--- a/seisbench/data/vcseis.py
+++ b/seisbench/data/vcseis.py
@@ -1,7 +1,7 @@
-from seisbench.data.base import BenchmarkDataset
+from seisbench.data.base import WaveformBenchmarkDataset
 
 
-class VCSEIS(BenchmarkDataset):
+class VCSEIS(WaveformBenchmarkDataset):
     """
     A data set of seismic waveforms from various volcanic regions: Alaska, Hawaii, Northern California, Cascade volcanoes.
 


### PR DESCRIPTION
So far, `BenchmarkDataset` inherited from `WaveformDataset`. However, this meant that it was impossible to reuse the download functionality for datasets with a different file structure. To fix this, all logic from the `BenchmarkDataset` was moved to an `AbstractBenchmarkDataset`. `BenchmarkDataset` now inherits from `AbstractBenchmarkDataset` (the download logic) and from `WaveformDataset` (the logic for handling the actual waveform data). The class BenchmarkDataset is renamed to `WaveformBenchmarkDataset`. For downward compatibility the alias `BenchmarkDataset` is kept, but issues a deprecation warning when used.