### PR TITLE
DRAFT: Change publishing workflow to use cibuildwheel

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -66,7 +66,7 @@ jobs:
     name: Upload if release
     # Disable publishing for manually triggered workflows
     if: |
-      startsWith(github.ref, 'refs/tags/') &&
+      startsWith(github.ref, 'refs/tags/v') &&
       github.event_name != 'workflow_dispatch'
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change is necessary due to the C code introduced in #386. Closes #392 

Only merge once the build process has been tested.