### PR TITLE
Fixed incompatibilities with pandas 3.0

### DIFF
--- a/seisbench/data/base.py
+++ b/seisbench/data/base.py
@@ -480,8 +480,8 @@ class WaveformDataset:
                 if np.any(np.isnan(self.metadata["trace_sampling_rate_hz"].values)):
                     # Implace NaN values. Useful if for parts of data set sampling rate is specified, and for others dt
                     mask = np.isnan(self.metadata["trace_sampling_rate_hz"].values)
-                    self._metadata["trace_sampling_rate_hz"].values[mask] = (
-                        1 / self.metadata["trace_dt_s"].values[mask]
+                    self._metadata.loc[mask, "trace_sampling_rate_hz"] = (
+                        1 / self.metadata.loc[mask, "trace_dt_s"]
                     )
 
                 q = (

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -407,7 +407,7 @@ def test_unify_sampling_rate(caplog):
     dummy = sbd.DummyDataset()
     caplog.clear()
     dummy._metadata["trace_sampling_rate_hz"] = 20.0
-    dummy._metadata["trace_sampling_rate_hz"].values[:20] = np.nan
+    dummy._metadata.loc[:20, "trace_sampling_rate_hz"] = np.nan
     dummy._metadata["trace_dt_s"] = 1 / 20.0
     del dummy._data_format["sampling_rate"]
     with caplog.at_level(logging.WARNING):
@@ -417,7 +417,7 @@ def test_unify_sampling_rate(caplog):
     dummy = sbd.DummyDataset()
     caplog.clear()
     dummy._metadata["trace_sampling_rate_hz"] = 20.0
-    dummy._metadata["trace_sampling_rate_hz"].values[:20] = np.nan
+    dummy._metadata.loc[:20, "trace_sampling_rate_hz"] = np.nan
     del dummy._data_format["sampling_rate"]
     with caplog.at_level(logging.WARNING):
         dummy._unify_sampling_rate()
@@ -426,7 +426,7 @@ def test_unify_sampling_rate(caplog):
     dummy = sbd.DummyDataset()
     caplog.clear()
     dummy._metadata["trace_sampling_rate_hz"] = 20.0
-    dummy._metadata["trace_sampling_rate_hz"].values[:20] = 40.0
+    dummy._metadata.loc[:20, "trace_sampling_rate_hz"] = 40.0
     del dummy._data_format["sampling_rate"]
     with caplog.at_level(logging.WARNING):
         dummy._unify_sampling_rate()
@@ -482,7 +482,7 @@ def test_unify_component_order(caplog):
 def test_resample():
     dummy = sbd.DummyDataset(metadata_cache=False)
     dummy._metadata["trace_sampling_rate_hz"] = 20.0
-    dummy._metadata["trace_sampling_rate_hz"].values[0] = np.nan
+    dummy._metadata.loc[0, "trace_sampling_rate_hz"] = np.nan
 
     # NaN sampling rate raises no error if sampling rate is None, but raises error otherwise
     dummy.get_waveforms(idx=0)


### PR DESCRIPTION
PR addresses, in particular, changes in mutability of objects

See also:
- https://pandas.pydata.org/community/blog/pandas-3.0.html
- https://pandas.pydata.org/docs/user_guide/copy_on_write.html#copy-on-write-migration-guide