### PR TITLE
Add parameter to control resampling filter (Closes #384)

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -479,8 +479,11 @@ def test_unify_component_order(caplog):
     assert (dummy._metadata["trace_component_order"] == "ZNE").all()
 
 
-def test_resample():
-    dummy = sbd.DummyDataset(metadata_cache=False)
+@pytest.mark.parametrize("zerophase_resample", [True, False])
+def test_resample(zerophase_resample):
+    dummy = sbd.DummyDataset(
+        metadata_cache=False, zerophase_resample=zerophase_resample
+    )
     dummy._metadata["trace_sampling_rate_hz"] = 20.0
     dummy._metadata.loc[0, "trace_sampling_rate_hz"] = np.nan
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -869,14 +869,15 @@ def test_dpp_ps():
     assert y.shape == (16, 500)
 
 
-def test_resample():
+@pytest.mark.parametrize("zerophase", [True, False])
+def test_resample(zerophase: bool):
     # Only tests for correct target frequencies and number of samples, but not for correct content
     t1 = obspy.Trace(np.random.rand(1000), header={"sampling_rate": 100})  # Decimate
     t2 = obspy.Trace(np.random.rand(1000), header={"sampling_rate": 25})  # Unchanged
     t3 = obspy.Trace(np.random.rand(1000), header={"sampling_rate": 40})  # Resample
 
     s = obspy.Stream([t1, t2, t3])
-    seisbench.models.WaveformModel.resample(s, 25)
+    seisbench.models.WaveformModel.resample(s, 25, zerophase=zerophase)
     assert s[0].stats.sampling_rate == 25
     assert len(s[0]) == 250
     assert s[1].stats.sampling_rate == 25


### PR DESCRIPTION
Resampling filter in both datasets and models can now be set to zerophase or causal. This behavior is also documented now.

Commit includes further minor edits to the documentation.