### PR TITLE
Fix depth phase models (closes #405)

### DIFF
--- a/seisbench/models/base.py
+++ b/seisbench/models/base.py
@@ -1785,10 +1785,17 @@ class WaveformModel(SeisBenchModel, ABC):
                 #     segment,
                 #     argdict,
                 # )
-                ret = self._stack_predictions_array_ext(
-                    segment,
-                    argdict,
-                )
+                if self._grouping.grouping == "full":
+                    # The external stacking option is not implemented for "full" grouping
+                    ret = self._stack_predictions_array(
+                        segment,
+                        argdict,
+                    )
+                else:
+                    ret = self._stack_predictions_array_ext(
+                        segment,
+                        argdict,
+                    )
 
                 await out_queue.put(ret)
                 # await asyncio.sleep(0)  # Yield control to event loop

--- a/seisbench/models/utils.py
+++ b/seisbench/models/utils.py
@@ -72,11 +72,17 @@ class PredictionSegment(TraceSegment):
 
     @property
     def n_samples(self) -> int:
-        return self.data.shape[0]
+        if self.data.ndim == 1:
+            return self.data.shape[0]
+        else:
+            return self.data.shape[-2]
 
     @property
     def n_channels(self) -> int:
-        return self.data.shape[1]
+        if self.data.ndim == 1:
+            return 1
+        else:
+            return self.data.shape[-1]
 
 
 class PredictionsStacked(NamedTuple):

--- a/tests/models/test_depthphase.py
+++ b/tests/models/test_depthphase.py
@@ -6,7 +6,7 @@ import obspy
 import pytest
 import torch
 from obspy import UTCDateTime
-from obspy.core.inventory import Channel, Inventory, Network, Station
+from obspy.core.inventory import Channel, Inventory, Network, Station, Site
 
 import seisbench.models
 
@@ -368,3 +368,81 @@ def test_depth_finder():
 
     output = depth_finder.get_depth(lat, lon, depth, org_time)
     assert isinstance(output.depth, float)
+
+
+@pytest.mark.parametrize(
+    "cls", [seisbench.models.DepthPhaseTEAM, seisbench.models.DepthPhaseNet]
+)
+def test_classify(cls):
+    t0 = obspy.UTCDateTime()
+    n_stations = 10
+    stream = obspy.Stream(
+        [
+            obspy.Trace(
+                data=np.random.rand(20000),
+                header={
+                    "network": "XY",
+                    "station": f"STA{idx}",
+                    "location": "",
+                    "channel": f"BH{c}",
+                    "starttime": t0,
+                    "sampling_rate": 20,
+                },
+            )
+            for c in "ZNE"
+            for idx in range(n_stations)
+        ]
+    )
+    picks = {f"XY.STA{idx}.": t0 + 50 for idx in range(n_stations)}
+    epicenter = (0.0, 0.0)
+
+    # Create random station coordinates
+    n_stations = 10
+    lats = np.random.uniform(-90, 90, n_stations)
+    lons = np.random.uniform(-180, 180, n_stations)
+    elevs = np.random.uniform(0, 2000, n_stations)  # meters
+
+    stations = []
+
+    for idx in range(n_stations):
+        sta_code = f"STA{idx}"
+        lat = lats[idx]
+        lon = lons[idx]
+        elev = elevs[idx]
+
+        channels = []
+        for comp in "ZNE":
+            cha = Channel(
+                code=f"BH{comp}",
+                location_code="",
+                latitude=lat,
+                longitude=lon,
+                elevation=elev,
+                depth=0.0,
+                azimuth={"Z": 0, "N": 0, "E": 90}[comp],
+                dip={"Z": -90, "N": 0, "E": 0}[comp],
+                sample_rate=100.0,
+            )
+            channels.append(cha)
+
+        sta = Station(
+            code=sta_code,
+            latitude=lat,
+            longitude=lon,
+            elevation=elev,
+            creation_date=t0,
+            site=Site(name=f"Random station {sta_code}"),
+            channels=channels,
+        )
+        stations.append(sta)
+
+    net = Network(
+        code="XY",
+        stations=stations,
+        description="Fake random network",
+    )
+
+    inventory = Inventory(networks=[net], source="synthetic")
+
+    model = cls()
+    model.classify(stream, picks, inventory=inventory, epicenter=epicenter)


### PR DESCRIPTION
The models failed because of an incompatibility with the new stacking procedure for fragments. Using the old stacking option now for models with grouping="full". Also adds a unit test to catch this type of issue in the future.