### PR TITLE
Update remote repository URL (Closes #403)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,25 +82,20 @@ Check out the [contribution guidelines](https://github.com/seisbench/seisbench/b
 
 ## Known issues
 
-- Some institutions and internet providers are blocking access to our data and model repository, as it is running on a non-standard port (2880).
-  This usually manifests in timeouts when trying to download data or model weights.
-  To verify the issue, try accessing [https://hifis-storage.desy.de:2880/](https://hifis-storage.desy.de:2880/) directly from the same machine.
+- We've experienced occasional issues with access to our repository.
+  To verify the issue, try accessing [https://hifis-storage.desy.de](https://hifis-storage.desy.de/) directly from the same machine.
   As a mitigation, you can use our backup repository. Just run `seisbench.use_backup_repository()`.
   Please note that the backup repository will usually show lower download speeds.
-  We recommend contacting your network administrator to allow outgoing access to TCP port 2880 on our server as a higher performance solution.
-- We've recently changed the URL of the SeisBench repository. To use the new URL update to SeisBench 0.4.1.
+- We've recently changed the URL of the SeisBench repository. To use the new URL update to SeisBench 0.11.5.
   It this is not possible, you can use the following commands within your runtime to update the URL manually:
   ```python
   import seisbench
   from urllib.parse import urljoin
 
-  seisbench.remote_root = "https://hifis-storage.desy.de:2880/Helmholtz/HelmholtzAI/SeisBench/"
+  seisbench.remote_root = "https://hifis-storage.desy.de/Helmholtz/HelmholtzAI/SeisBench/"
   seisbench.remote_data_root = urljoin(seisbench.remote_root, "datasets/")
   seisbench.remote_model_root = urljoin(seisbench.remote_root, "models/v3/")
   ```
-- On the Apple M1 and M2 chips, pytorch seems to not always work when installed directly within `pip install seisbench`.
-  As a workaround, follow the instructions at (https://pytorch.org/) to install pytorch and then install SeisBench as usual through pip.
-- EQTransformer model weights "original" in version 1 and 2 are incompatible with SeisBench >=0.2.3. Simply use `from_pretrained("original", version="3")` or `from_pretrained("original", update=True)`. The weights will not differ in their predictions.
 
 ## References
 Reference publications for SeisBench:

--- a/docs/pages/installation_and_usage.rst
+++ b/docs/pages/installation_and_usage.rst
@@ -43,11 +43,9 @@ Configuring the remote repository
 
 SeisBench uses a remote repository to serve datasets and model weights from.
 This repository is hosted on dCache, a high-performance large scale data storage, delivering very high download speeds.
-Unfortunately, this comes at the cost of running on a non-standard port for the data transfer that some institutions/providers block.
 You can find the server URL by calling `seisbench.remote_root`.
-While we highly recommend users to get in touch with their IT department to allow access to our server,
-we understand that this might not be possible for all users.
-Therefore, we offer a backup server. To use the backup server, simply call `seisbench.use_backup_repository()`.
+As we have experienced occasional issues with this server, we offer a backup server.
+To use the backup server, simply call `seisbench.use_backup_repository()`.
 This will change the repository used within the current runtime.
 For a more permanent solution, put the backup repository into your SeisBench config file (usually at `.seisbench/config.json`).
 Simply add the following line: ::

--- a/seisbench/__init__.py
+++ b/seisbench/__init__.py
@@ -48,9 +48,7 @@ _ch.setFormatter(
 logger.addHandler(_ch)
 
 
-default_remote_root = (
-    "https://hifis-storage.desy.de:2880/Helmholtz/HelmholtzAI/SeisBench/"
-)
+default_remote_root = "https://hifis-storage.desy.de/Helmholtz/HelmholtzAI/SeisBench/"
 backup_remote_root = "https://seisbench.gfz.de/mirror/"
 
 remote_root = config.get("remote_root", default_remote_root)


### PR DESCRIPTION
As the repository now runs on a standard port, all references mentioning the non-standard port have been removed. The backup repository is kept nonetheless.