### PR TITLE
Improvements to DAS model interface

### DIFF
--- a/seisbench/models/das_base.py
+++ b/seisbench/models/das_base.py
@@ -1042,7 +1042,9 @@ class WriterBuffer:
                     finalized_sample = 0
 
                 output = (
-                    finalized_segment,
+                    finalized_segment.astype(
+                        self._dtype
+                    ),  # Type cast required because float32 / uint32 -> float64
                     PatchCoordinate(
                         finalized_sample,
                         0,

--- a/seisbench/models/das_base.py
+++ b/seisbench/models/das_base.py
@@ -672,12 +672,15 @@ class DASPickingCallback(DASAnnotateCallback):
     :param thresholds: Confidence thresholds for picking. Can be a single value for all phases,
                        or a dictionary with thresholds per phase.
     :param min_time_separation: Minimum time separation between two picks of the same phase in seconds.
+    :param blinding: Number of samples to ignore at the start and end of each window for picking. Useful to avoid
+                     boundary artifacts in picking.
     """
 
     def __init__(
         self,
         thresholds: float | dict[str, float] = 0.2,
         min_time_separation: float = 1.0,
+        blinding: tuple[int, int] = (100, 100),
     ):
         self._picks: dict[str, list[sbu.DASPick]] = {}
         self._picks_per_channel_idx: dict[tuple[str, int], list[sbu.DASPick]] = (
@@ -685,6 +688,7 @@ class DASPickingCallback(DASAnnotateCallback):
         )
         self.thresholds = thresholds
         self.min_time_separation = min_time_separation
+        self.blinding = blinding
 
         self._thresholds: dict[str, float] = {}
         self._annotate_keys: list[str] = []
@@ -732,7 +736,7 @@ class DASPickingCallback(DASAnnotateCallback):
             for channel_idx in range(ann.shape[1]):
                 if (ann[:, channel_idx] > threshold).any():
                     peaks, peak_properties = scipy.signal.find_peaks(
-                        ann[:, channel_idx],
+                        ann[self.blinding[0] : -self.blinding[1], channel_idx],
                         height=threshold,
                         distance=min_separation_samples,
                     )
@@ -740,7 +744,7 @@ class DASPickingCallback(DASAnnotateCallback):
                         self._picks_per_channel_idx[(key, channel_idx)].append(
                             sbu.DASPick(
                                 time=self._translate_coords(
-                                    out_coords.sample + peak, "time"
+                                    out_coords.sample + self.blinding[0] + peak, "time"
                                 ),
                                 channel=self._translate_coords(
                                     out_coords.channel + channel_idx,

--- a/seisbench/models/das_base.py
+++ b/seisbench/models/das_base.py
@@ -835,6 +835,10 @@ class WriterBuffer:
             self._channel_buffer_count = None
             self._previous_sample_buffer_count = None
             self._current_sample_buffer_count = None
+        elif self.stacking == "weighted":
+            self._channel_buffer_weight = None
+            self._previous_sample_buffer_weight = None
+            self._current_sample_buffer_weight = None
 
     @property
     def stacking(self) -> str:
@@ -842,9 +846,16 @@ class WriterBuffer:
 
     @stacking.setter
     def stacking(self, value: str):
-        if value not in ["avg", "max"]:
-            raise ValueError("Stacking must be either 'avg' or 'max'.")
+        if value not in ["avg", "max", "weighted"]:
+            raise ValueError("Stacking must be either 'avg', 'max', or 'weighted'.")
         self._stacking = value
+
+    @staticmethod
+    def _get_weight_mask(shape: tuple[int]):
+        # A 2D Hanning window with a lower clip at 1e-5 to avoid division by zero
+        return np.clip(
+            np.hanning(shape[0]).reshape(-1, 1) * np.hanning(shape[1]), 1e-5, None
+        ).astype(np.float32)
 
     def add_data(
         self, data: np.ndarray, out_coords: PatchCoordinate
@@ -861,6 +872,9 @@ class WriterBuffer:
 
         output = None
 
+        if self.stacking == "weighted":
+            data = data * self._get_weight_mask(data.shape)
+
         if self._last_channel is None:
             if out_coords.channel > 0:
                 raise ValueError("Each row needs to start at channel 0.")
@@ -869,6 +883,10 @@ class WriterBuffer:
                 self._channel_buffer_count = np.ones_like(
                     self._channel_buffer, dtype=np.uint32
                 )
+            elif self.stacking == "weighted":
+                self._channel_buffer_weight = np.zeros_like(
+                    self._channel_buffer, dtype=np.float32
+                ) + self._get_weight_mask(data.shape)
             finalized_segment = None
             self._last_channel = 0
         else:
@@ -883,6 +901,10 @@ class WriterBuffer:
             finalized_segment = self._channel_buffer[:, :boundary_channels]
             if self.stacking == "avg":
                 finalized_segment_count = self._channel_buffer_count[
+                    :, :boundary_channels
+                ]
+            elif self.stacking == "weighted":
+                finalized_segment_weight = self._channel_buffer_weight[
                     :, :boundary_channels
                 ]
 
@@ -906,6 +928,17 @@ class WriterBuffer:
                 ]
                 tmp_buffer_count += 1
                 self._channel_buffer_count = tmp_buffer_count
+            elif self.stacking == "weighted":
+                tmp_buffer[:, :-boundary_channels] = (
+                    self._channel_buffer[:, boundary_channels:]
+                    + data[:, :-boundary_channels]
+                )
+                tmp_buffer_weight = np.zeros_like(tmp_buffer, dtype=np.float32)
+                tmp_buffer_weight[:, :-boundary_channels] = self._channel_buffer_weight[
+                    :, boundary_channels:
+                ]
+                tmp_buffer_weight += self._get_weight_mask(data.shape)
+                self._channel_buffer_weight = tmp_buffer_weight
 
             self._channel_buffer = tmp_buffer
 
@@ -917,6 +950,8 @@ class WriterBuffer:
                 finalized_segment = self._channel_buffer
                 if self.stacking == "avg":
                     finalized_segment_count = self._channel_buffer_count
+                elif self.stacking == "weighted":
+                    finalized_segment_weight = self._channel_buffer_weight
             else:
                 finalized_segment = np.concatenate(
                     [finalized_segment, self._channel_buffer], axis=1
@@ -924,6 +959,10 @@ class WriterBuffer:
                 if self.stacking == "avg":
                     finalized_segment_count = np.concatenate(
                         [finalized_segment_count, self._channel_buffer_count], axis=1
+                    )
+                elif self.stacking == "weighted":
+                    finalized_segment_weight = np.concatenate(
+                        [finalized_segment_weight, self._channel_buffer_weight], axis=1
                     )
 
         # Update sample buffer - Note that horizontal overlap is already handled
@@ -934,6 +973,10 @@ class WriterBuffer:
             if self.stacking == "avg":
                 self._current_sample_buffer_count = np.zeros_like(
                     self._current_sample_buffer, dtype=np.uint32
+                )
+            elif self.stacking == "weighted":
+                self._current_sample_buffer_weight = np.zeros_like(
+                    self._current_sample_buffer, dtype=np.float32
                 )
             self._current_sample = out_coords.sample_int
 
@@ -947,6 +990,12 @@ class WriterBuffer:
                     self._last_channel : self._last_channel
                     + finalized_segment.shape[1],
                 ] = finalized_segment_count
+            elif self.stacking == "weighted":
+                self._current_sample_buffer_weight[
+                    :,
+                    self._last_channel : self._last_channel
+                    + finalized_segment.shape[1],
+                ] = finalized_segment_weight
 
         self._last_channel = out_coords.channel_int
 
@@ -962,12 +1011,20 @@ class WriterBuffer:
                     self._previous_sample_buffer_count = (
                         self._current_sample_buffer_count
                     )
+                elif self.stacking == "weighted":
+                    self._previous_sample_buffer_weight = (
+                        self._current_sample_buffer_weight
+                    )
                 self._previous_sample = self._current_sample
             else:
                 boundary_samples = self._current_sample - self._previous_sample
                 finalized_segment = self._previous_sample_buffer[:boundary_samples]
                 if self.stacking == "avg":
                     finalized_segment_count = self._previous_sample_buffer_count[
+                        :boundary_samples
+                    ]
+                elif self.stacking == "weighted":
+                    finalized_segment_weight = self._previous_sample_buffer_weight[
                         :boundary_samples
                     ]
 
@@ -995,6 +1052,17 @@ class WriterBuffer:
                     )
                     tmp_buffer_count += self._current_sample_buffer_count
                     self._previous_sample_buffer_count = tmp_buffer_count
+                elif self.stacking == "weighted":
+                    tmp_buffer[:-boundary_samples] = (
+                        self._previous_sample_buffer[boundary_samples:]
+                        + self._current_sample_buffer[:-boundary_samples]
+                    )
+                    tmp_buffer_weight = np.zeros_like(tmp_buffer, dtype=np.float32)
+                    tmp_buffer_weight[:-boundary_samples] = (
+                        self._previous_sample_buffer_weight[boundary_samples:]
+                    )
+                    tmp_buffer_weight += self._current_sample_buffer_weight
+                    self._previous_sample_buffer_weight = tmp_buffer_weight
 
                 finalized_sample = self._previous_sample
                 self._previous_sample_buffer = tmp_buffer
@@ -1015,6 +1083,8 @@ class WriterBuffer:
                     finalized_segment = self._previous_sample_buffer
                     if self.stacking == "avg":
                         finalized_segment_count = self._previous_sample_buffer_count
+                    elif self.stacking == "weighted":
+                        finalized_segment_weight = self._previous_sample_buffer_weight
                 else:
                     finalized_segment = np.concatenate(
                         [finalized_segment, self._previous_sample_buffer], axis=0
@@ -1027,6 +1097,14 @@ class WriterBuffer:
                             ],
                             axis=0,
                         )
+                    elif self.stacking == "weighted":
+                        finalized_segment_weight = np.concatenate(
+                            [
+                                finalized_segment_weight,
+                                self._previous_sample_buffer_weight,
+                            ],
+                            axis=0,
+                        )
 
                 self._previous_sample_buffer = None
                 self._previous_sample_buffer_count = None
@@ -1034,6 +1112,11 @@ class WriterBuffer:
             if finalized_segment is not None:
                 if self.stacking == "avg":
                     finalized_segment = finalized_segment / finalized_segment_count
+                elif self.stacking == "weighted":
+                    # The clipping will downweight values with very low coverage
+                    finalized_segment = finalized_segment / np.clip(
+                        finalized_segment_weight, 1e-8, None
+                    )
                 else:
                     # Copy to avoid passing out pointers to a view of a large array
                     finalized_segment = finalized_segment.copy()
@@ -1083,10 +1166,10 @@ class WriterCallback(DASAnnotateCallback):
     ``data.coords["time"] = data.coords["time"].simplify(tolerance=np.timedelta64(1, "us"))``.
     """
 
-    def __init__(self, output_path: Path | str, stacking: str = "avg"):
+    def __init__(self, output_path: Path | str, stacking: str = "weighted"):
         self.output_path = Path(output_path)
         self.output_path.mkdir(parents=False, exist_ok=True)
-        if stacking not in ["avg", "max"]:
+        if stacking not in ["avg", "max", "weighted"]:
             raise ValueError("Stacking must be either 'avg' or 'max'.")
         self.stacking = stacking
 
@@ -1162,7 +1245,7 @@ class InMemoryCollectionCallback(DASAnnotateCallback):
     patches. To avoid memory overflows, this callback should only be used for small datasets.
     """
 
-    def __init__(self, stacking: str = "avg"):
+    def __init__(self, stacking: str = "weighted"):
         self.annotations = None
         self.stacking = stacking
 

--- a/tests/models/test_das_base_models.py
+++ b/tests/models/test_das_base_models.py
@@ -543,7 +543,7 @@ def test_calc_output_shape_and_coordinates(dense_coordinates):
 
 @pytest.mark.parametrize("sample_length_factor", [1, 1.1, 4.5])
 @pytest.mark.parametrize("channel_length_factor", [1, 1.1, 4.5])
-@pytest.mark.parametrize("stacking", ["max", "avg"])
+@pytest.mark.parametrize("stacking", ["max", "avg", "weighted"])
 @pytest.mark.parametrize("overlap", [0.0, 0.5])
 def test_inmemory_collection_callback(
     sample_length_factor, channel_length_factor, stacking, overlap
@@ -581,7 +581,7 @@ def test_inmemory_collection_callback(
     assert np.allclose(da.data, callback.annotations["x"].data)
 
 
-@pytest.mark.parametrize("stacking", ["max", "avg"])
+@pytest.mark.parametrize("stacking", ["max", "avg", "weighted"])
 @pytest.mark.parametrize("overlap", [0.0, 0.5])
 def test_writer_callback(tmp_path, stacking, overlap):
     model = DemoModel()


### PR DESCRIPTION
This PR adds several improvements for DAS models, in particular for dealing with boundary artifacts.
- The DASPickingCallback now has a blinding argument that is applied along the sample axis. Within this blind window, no picks will be extracted.
- The InMemoryCollectionCallback and WriterCallback now both default to a "weighted" stacking option which downweights boundary samples without introducing a discontinuity.
- The WriteBuffer uses an additional dtype conversion for the output, as some configurations could lead to incorrect output types.